### PR TITLE
Implement Events used by Apathetic Mobs

### DIFF
--- a/patchwork-events-entity/src/main/java/com/patchworkmc/impl/event/entity/EntityEvents.java
+++ b/patchwork-events-entity/src/main/java/com/patchworkmc/impl/event/entity/EntityEvents.java
@@ -22,6 +22,7 @@ package com.patchworkmc.impl.event.entity;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
+import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
@@ -80,6 +81,10 @@ public class EntityEvents implements ModInitializer {
 
 	public static boolean onLivingAttack(LivingEntity entity, DamageSource src, float damage) {
 		return MinecraftForge.EVENT_BUS.post(new LivingAttackEvent(entity, src, damage));
+	}
+
+	public static void onLivingSetAttackTarget(LivingEntity entity, LivingEntity target) {
+		MinecraftForge.EVENT_BUS.post(new LivingSetAttackTargetEvent(entity, target));
 	}
 
 	public static float onLivingHurt(LivingEntity entity, DamageSource src, float damage) {

--- a/patchwork-events-entity/src/main/java/com/patchworkmc/impl/event/entity/EntityEvents.java
+++ b/patchwork-events-entity/src/main/java/com/patchworkmc/impl/event/entity/EntityEvents.java
@@ -25,6 +25,7 @@ import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.event.entity.living.LivingDamageEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -89,6 +90,11 @@ public class EntityEvents implements ModInitializer {
 
 	public static float onLivingHurt(LivingEntity entity, DamageSource src, float damage) {
 		LivingHurtEvent event = new LivingHurtEvent(entity, src, damage);
+		return MinecraftForge.EVENT_BUS.post(event) ? 0 : event.getAmount();
+	}
+
+	public static float onLivingDamage(LivingEntity entity, DamageSource src, float damage) {
+		LivingDamageEvent event = new LivingDamageEvent(entity, src, damage);
 		return MinecraftForge.EVENT_BUS.post(event) ? 0 : event.getAmount();
 	}
 

--- a/patchwork-events-entity/src/main/java/com/patchworkmc/mixin/event/entity/MixinLivingEntity.java
+++ b/patchwork-events-entity/src/main/java/com/patchworkmc/mixin/event/entity/MixinLivingEntity.java
@@ -75,4 +75,13 @@ public class MixinLivingEntity {
 			info.cancel();
 		}
 	}
+
+	// No shift, because we are specifically not modifying the value for this function call.
+	// TODO: Forge patches a bit later into the function here, being inconsistent with their patch for PlayerEntity. For the moment, I don't feel like finding an injection point for that, and this may be a Forge bug?
+	@ModifyVariable(method = "applyDamage", argsOnly = true, at = @At(value = "INVOKE", target = "net/minecraft/entity/LivingEntity.setAbsorptionAmount (F)V", ordinal = 0))
+	private float hookApplyDamageForDamageEvent(float damage, DamageSource source) {
+		LivingEntity entity = (LivingEntity) (Object) this;
+
+		return EntityEvents.onLivingDamage(entity, source, damage);
+	}
 }

--- a/patchwork-events-entity/src/main/java/com/patchworkmc/mixin/event/entity/MixinMobEntity.java
+++ b/patchwork-events-entity/src/main/java/com/patchworkmc/mixin/event/entity/MixinMobEntity.java
@@ -1,0 +1,39 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package com.patchworkmc.mixin.event.entity;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.mob.MobEntity;
+
+import com.patchworkmc.impl.event.entity.EntityEvents;
+
+@Mixin(MobEntity.class)
+public class MixinMobEntity {
+	@Inject(method = "setTarget", at = @At("TAIL"))
+	private void hookSetTarget(LivingEntity target, CallbackInfo callback) {
+		LivingEntity entity = (LivingEntity) (Object) this;
+		EntityEvents.onLivingSetAttackTarget(entity, target);
+	}
+}

--- a/patchwork-events-entity/src/main/java/com/patchworkmc/mixin/event/entity/MixinPlayerEntity.java
+++ b/patchwork-events-entity/src/main/java/com/patchworkmc/mixin/event/entity/MixinPlayerEntity.java
@@ -98,4 +98,12 @@ public class MixinPlayerEntity {
 			info.cancel();
 		}
 	}
+
+	// No shift, because we are specifically not modifying the value for this function call.
+	@ModifyVariable(method = "applyDamage", argsOnly = true, at = @At(value = "INVOKE", target = "net/minecraft/entity/player/PlayerEntity.setAbsorptionAmount (F)V", ordinal = 0))
+	private float hookApplyDamageForDamageEvent(float damage, DamageSource source) {
+		LivingEntity entity = (LivingEntity) (Object) this;
+
+		return EntityEvents.onLivingDamage(entity, source, damage);
+	}
 }

--- a/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/living/LivingDamageEvent.java
+++ b/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/living/LivingDamageEvent.java
@@ -1,0 +1,66 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.LivingEntity;
+
+/**
+ * LivingDamageEvent is fired just before damage is applied to entity.
+ *
+ * <p>At this point armor, potion and absorption modifiers have already been applied to damage - this is FINAL value.</p>
+ * <p>Also note that appropriate resources (like armor durability and absorption extra hearths) have already been consumed.</p>
+ * <p>This event is fired whenever an Entity is damaged in
+ * {@link LivingEntity#applyDamage(DamageSource, float)} and
+ * {@link net.minecraft.entity.player.PlayerEntity#applyDamage(DamageSource, float)}.</p>
+ *
+ * <p>This event is fired via the {@link com.patchworkmc.impl.event.entity.EntityEvents#onLivingDamage(LivingEntity, DamageSource, float)}.</p>
+ *
+ * <p>{@link #source} contains the DamageSource that caused this Entity to be hurt. </p>
+ * <p>{@link #amount} contains the final amount of damage that will be dealt to entity. </p>
+ *
+ * <p>This event is cancelable.</p>
+ * <p>If this event is canceled, the Entity is not hurt. Used resources WILL NOT be restored.</p>
+ *
+ * <p>This event does not have a result.</p>
+ * @see LivingHurtEvent
+ */
+public class LivingDamageEvent extends LivingEvent {
+	private final DamageSource source;
+	private float amount;
+
+	public LivingDamageEvent(LivingEntity entity, DamageSource source, float amount) {
+		super(entity);
+		this.source = source;
+		this.amount = amount;
+	}
+
+	public DamageSource getSource() {
+		return source;
+	}
+
+	public float getAmount() {
+		return amount;
+	}
+
+	public void setAmount(float amount) {
+		this.amount = amount;
+	}
+}

--- a/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/living/LivingSetAttackTargetEvent.java
+++ b/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/living/LivingSetAttackTargetEvent.java
@@ -1,0 +1,58 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.mob.MobEntity;
+
+/**
+ * LivingSetAttackTargetEvent is fired when an entity sets a target to attack.
+ *
+ * <p>This event is fired whenever a {@link MobEntity} sets a target to attack in
+ * {@link MobEntity#setTarget(LivingEntity)}.</p>
+ *
+ * <p>This event is fired via {@link com.patchworkmc.impl.event.entity.EntityEvents#onLivingSetAttackTarget(LivingEntity, LivingEntity)}.</p>
+ *
+ * <p>{@link #target} contains the newly targeted Entity.</p>
+ *
+ * <p>This event is not cancellable.</p>
+ *
+ * <p>This event does not have a result.</p>
+ *
+ * <p>This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.</p>
+ */
+public class LivingSetAttackTargetEvent extends LivingEvent {
+	private final LivingEntity target;
+
+	// for EventBus
+	public LivingSetAttackTargetEvent() {
+		super();
+		this.target = null;
+	}
+
+	public LivingSetAttackTargetEvent(LivingEntity entity, LivingEntity target) {
+		super(entity);
+		this.target = target;
+	}
+
+	public LivingEntity getTarget() {
+		return target;
+	}
+}

--- a/patchwork-events-entity/src/main/resources/patchwork-events-entity.mixins.json
+++ b/patchwork-events-entity/src/main/resources/patchwork-events-entity.mixins.json
@@ -5,6 +5,7 @@
   "mixins": [
     "MixinEntityType",
     "MixinLivingEntity",
+    "MixinMobEntity",
     "MixinMobSpawnerLogic",
     "MixinPlayerEntity",
     "MixinPlayerManager",

--- a/patchwork-events-world/src/main/java/net/minecraftforge/event/DifficultyChangeEvent.java
+++ b/patchwork-events-world/src/main/java/net/minecraftforge/event/DifficultyChangeEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.Event;
+
+import net.minecraft.world.Difficulty;
+
+/**
+ * DifficultyChangeEvent is fired when difficulty is changing.
+ *
+ * <p>TODO: Forge bug: This event is not currently fired. See https://github.com/MinecraftForge/MinecraftForge/issues/6227</p>
+ *
+ * <p>This event is not cancellable.</p>
+ *
+ * <p>This event does not have a result.</p>
+ *
+ * <p>This event is fired on the {@link MinecraftForge#EVENT_BUS}.</p>
+ */
+public class DifficultyChangeEvent extends Event {
+	private final Difficulty difficulty;
+	private final Difficulty oldDifficulty;
+
+	public DifficultyChangeEvent(Difficulty difficulty, Difficulty oldDifficulty) {
+		this.difficulty = difficulty;
+		this.oldDifficulty = oldDifficulty;
+	}
+
+	public Difficulty getDifficulty() {
+		return difficulty;
+	}
+
+	public Difficulty getOldDifficulty() {
+		return oldDifficulty;
+	}
+}


### PR DESCRIPTION
Note: This is currently untested (other than "does it crash the game on startup/playing/shutdown singleplayer"), as Apathetic Mobs also requires #19 and the corresponding changes in patchwork-patcher. Once it has been tested (either through testmods or through real mods) it can be taken out of draft status.

I have a few comments/suggestions for reviewers, which I will add using the review feature.