### PR TITLE
Add the PlayerEvent.StartTracking and StopTracking events

### DIFF
--- a/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -22,6 +22,7 @@ package net.minecraftforge.event.entity.player;
 import net.minecraftforge.event.entity.living.LivingEvent;
 
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.Entity;
 
 /**
  * PlayerEvent is fired whenever an event involving Living entities occurs.
@@ -66,13 +67,43 @@ public class PlayerEvent extends LivingEvent {
 		}
 	}
 
+	/**
+	 * Fired when an Entity is started to be "tracked" by this player (the player receives updates about this entity, e.g. motion).
+	 */
+	public static class StartTracking extends PlayerEvent {
+		private final Entity target;
+
+		public StartTracking(PlayerEntity player, Entity target) {
+			super(player);
+			this.target = target;
+		}
+
+		public Entity getTarget() {
+			return target;
+		}
+	}
+
+	/**
+	 * Fired when an Entity is started to be "tracked" by this player (the player receives updates about this entity, e.g. motion).
+	 */
+	public static class StopTracking extends PlayerEvent {
+		private final Entity target;
+
+		public StopTracking(PlayerEntity player, Entity target) {
+			super(player);
+			this.target = target;
+		}
+
+		public Entity getTarget() {
+			return target;
+		}
+	}
+
 	/*TODO Events:
 	HarvestCheck
 	BreakSpeed
 	NameFormat
 	Clone
-	StartTracking
-	StopTracking
 	LoadFromFile
 	SaveToFile
 	Visibility

--- a/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinEntityTrackerEntry.java
+++ b/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinEntityTrackerEntry.java
@@ -1,0 +1,48 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.event.entity;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.server.network.EntityTrackerEntry;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+@Mixin(EntityTrackerEntry.class)
+public class MixinEntityTrackerEntry {
+	@Shadow
+	private Entity entity;
+
+	@Inject(method = "startTracking", at = @At("TAIL"))
+	private void hookEventStartTracking(ServerPlayerEntity player, CallbackInfo callback) {
+		MinecraftForge.EVENT_BUS.post(new PlayerEvent.StartTracking(player, entity));
+	}
+
+	@Inject(method = "stopTracking", at = @At("TAIL"))
+	private void hookEventStopTracking(ServerPlayerEntity player, CallbackInfo callback) {
+		MinecraftForge.EVENT_BUS.post(new PlayerEvent.StopTracking(player, entity));
+	}
+}

--- a/patchwork-events-entity/src/main/resources/patchwork-events-entity.mixins.json
+++ b/patchwork-events-entity/src/main/resources/patchwork-events-entity.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinEntity",
+    "MixinEntityTrackerEntry",
     "MixinEntityType",
     "MixinLivingEntity",
     "MixinMobEntity",
@@ -13,8 +14,7 @@
     "MixinServerPlayerEntity",
     "MixinServerWorld",
     "MixinSpawnHelper",
-    "MixinWorldChunk",
-    "MixinEntityTrackerEntry"
+    "MixinWorldChunk"
   ],
   "client": [
     "MixinClientWorld",

--- a/patchwork-events-entity/src/main/resources/patchwork-events-entity.mixins.json
+++ b/patchwork-events-entity/src/main/resources/patchwork-events-entity.mixins.json
@@ -13,7 +13,8 @@
     "MixinServerPlayerEntity",
     "MixinServerWorld",
     "MixinSpawnHelper",
-    "MixinWorldChunk"
+    "MixinWorldChunk",
+    "MixinEntityTrackerEntry"
   ],
   "client": [
     "MixinClientWorld",


### PR DESCRIPTION
As the title implies, this adds two events that mark when position updates and such start and stop being sent to a player as they move in and out of range.

These are used by Curios - See #84.