### PR TITLE
Add more missing function to ModList, FMLModContainer and ModContainer

### DIFF
--- a/patchwork-dispatcher/src/main/java/net/patchworkmc/impl/Patchwork.java
+++ b/patchwork-dispatcher/src/main/java/net/patchworkmc/impl/Patchwork.java
@@ -32,6 +32,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModContainer;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
@@ -112,6 +113,7 @@ public class Patchwork implements ModInitializer {
 			throw error;
 		}
 
+		ModList.get().setLoadedMods(mods.values());
 		// Send initialization events
 
 		RegistryEventDispatcher.dispatchRegistryEvents(event -> dispatch(mods, event));

--- a/patchwork-fml/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/patchwork-fml/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -21,13 +21,15 @@ package net.minecraftforge.fml;
 
 import java.util.EnumMap;
 
+import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.config.ModConfig;
 
 // TODO: Stub
-public class ModContainer {
+public abstract class ModContainer {
 	protected final String modId;
 	protected final String namespace;
 	protected final EnumMap<ModConfig.Type, ModConfig> configs;
+	private net.fabricmc.loader.api.ModContainer fabricModContainer;
 
 	public ModContainer(String modId) {
 		this.modId = modId;
@@ -46,5 +48,18 @@ public class ModContainer {
 
 	public void addConfig(final ModConfig modConfig) {
 		configs.put(modConfig.getType(), modConfig);
+	}
+
+	public final void setParent(net.fabricmc.loader.api.ModContainer fabricModContainer) {
+		this.fabricModContainer = fabricModContainer;
+	}
+
+	public final net.fabricmc.loader.api.ModContainer getParent() {
+		return this.fabricModContainer;
+	}
+
+	public abstract Object getMod();
+
+	protected void acceptEvent(Event e) {
 	}
 }

--- a/patchwork-fml/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/patchwork-fml/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -1,0 +1,38 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml;
+
+import net.minecraftforge.eventbus.api.Event;
+
+public class ModLoader {
+	private static ModLoader INSTANCE;
+
+	private ModLoader() {
+		INSTANCE = this;
+	}
+
+	public static ModLoader get() {
+		return INSTANCE == null ? INSTANCE = new ModLoader() : INSTANCE;
+	}
+
+	public void postEvent(Event e) {
+		ModList.get().forEachModContainer((id, mc) -> mc.acceptEvent(e));
+	}
+}

--- a/patchwork-fml/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/patchwork-fml/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -27,6 +27,7 @@ import net.minecraftforge.fml.ModContainer;
 
 public class FMLModContainer extends ModContainer {
 	private final IEventBus eventBus;
+	private Object instance;
 
 	public FMLModContainer(String id) {
 		super(id);
@@ -46,5 +47,19 @@ public class FMLModContainer extends ModContainer {
 
 	private void onEventFailed(IEventBus iEventBus, Event event, IEventListener[] listeners, int i, Throwable throwable) {
 		// TODO
+	}
+
+	@Override
+	protected void acceptEvent(final Event e) {
+		this.eventBus.post(e);
+	}
+
+	@Override
+	public Object getMod() {
+		return this.instance;
+	}
+
+	public void setMod(Object instance) {
+		this.instance = instance;
 	}
 }


### PR DESCRIPTION
FMLModContainer and ModContainer:
 [API] Add getMod and acceptEvent methods
 [Internal] setParent and getParent: associated Fabric ModContainer
getter and setters

ModList:
 Add most helper functions present in Forge's ModList, these are
frequenty used by mods

ModLoader(class):
 A class may used by mods to post event on the FML event bus

TODO:
the ModContainer.setMod(Object) is not called anywhere in the code, I don't know how the forge mod main class instance is created. This is the only problem.