### PR TITLE
Add the PlayerXpEvent events (add XP points/level, pickup XP orb)

### DIFF
--- a/patchwork-events-entity/build.gradle
+++ b/patchwork-events-entity/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "patchwork-events-entity"
-version = getSubprojectVersion(project, "0.3.0")
+version = getSubprojectVersion(project, "0.4.0")
 
 dependencies {
 	compile project(path: ':patchwork-fml', configuration: 'dev')

--- a/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/player/PlayerPickupXpEvent.java
+++ b/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/player/PlayerPickupXpEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.ExperienceOrbEntity;
+import net.minecraft.entity.player.PlayerEntity;
+
+/**
+ * Legacy version of PlayerXpEvent.PickupXp. Mods should move to PickupXp, and
+ * this class is removed in 1.15.
+ */
+@Deprecated
+public class PlayerPickupXpEvent extends PlayerXpEvent.PickupXp {
+	public PlayerPickupXpEvent(PlayerEntity player, ExperienceOrbEntity orb) {
+		super(player, orb);
+	}
+}

--- a/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
+++ b/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
@@ -1,0 +1,90 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.ExperienceOrbEntity;
+import net.minecraft.entity.player.PlayerEntity;
+
+public abstract class PlayerXpEvent extends PlayerEvent {
+	public PlayerXpEvent(PlayerEntity player) {
+		super(player);
+	}
+
+	// For legacy reasons, the instances of this class should actually be of
+	// type PlayerPickupXpEvent
+	public static class PickupXp extends CancelablePlayerXpEvent {
+		private final ExperienceOrbEntity orb;
+
+		public PickupXp(PlayerEntity player, ExperienceOrbEntity orb) {
+			super(player);
+			this.orb = orb;
+		}
+
+		public ExperienceOrbEntity getOrb() {
+			return orb;
+		}
+	}
+
+	public static class XpChange extends CancelablePlayerXpEvent {
+		private int amount;
+
+		public XpChange(PlayerEntity player, int amount) {
+			super(player);
+			this.amount = amount;
+		}
+
+		public int getAmount() {
+			return amount;
+		}
+
+		public void setAmount(int amount) {
+			this.amount = amount;
+		}
+	}
+
+	public static class LevelChange extends CancelablePlayerXpEvent {
+		private int levels;
+
+		public LevelChange(PlayerEntity player, int levels) {
+			super(player);
+			this.levels = levels;
+		}
+
+		public int getLevels() {
+			return this.levels;
+		}
+
+		public void setLevels(int levels) {
+			this.levels = levels;
+		}
+	}
+
+	// Helper, so we don't have to repeat isCancelable all the time
+	private static class CancelablePlayerXpEvent extends PlayerXpEvent {
+		private CancelablePlayerXpEvent(PlayerEntity player) {
+			super(player);
+		}
+
+		@Override
+		public boolean isCancelable() {
+			return true;
+		}
+	}
+}

--- a/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
+++ b/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/player/PlayerXpEvent.java
@@ -27,8 +27,13 @@ public abstract class PlayerXpEvent extends PlayerEvent {
 		super(player);
 	}
 
-	// For legacy reasons, the instances of this class should actually be of
-	// type PlayerPickupXpEvent
+	/**
+	 * An event representing a player picking up an XP orb entity.
+	 * <p>
+	 * For legacy reasons, the instances of this class should actually be of
+	 * type {@link PlayerPickupXpEvent}
+	 * </p>
+	 */
 	public static class PickupXp extends CancelablePlayerXpEvent {
 		private final ExperienceOrbEntity orb;
 

--- a/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinExperienceOrbEntity.java
+++ b/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinExperienceOrbEntity.java
@@ -1,0 +1,47 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.event.entity;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerPickupXpEvent;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.ExperienceOrbEntity;
+
+@Mixin(ExperienceOrbEntity.class)
+public class MixinExperienceOrbEntity {
+	// After checking we're on the server and the player is ready to pick up the orb, the first
+	// thing the target method does is set experiencePickUpDelay, hence hook just before that.
+	@Inject(method = "onPlayerCollision", cancellable = true, at = @At(value = "FIELD", opcode = Opcodes.H_PUTFIELD, ordinal = 0,
+			target = "net/minecraft/entity/player/PlayerEntity.experiencePickUpDelay:I"))
+	private void hookOnPlayerCollisionForPickup(PlayerEntity player, CallbackInfo ci) {
+		@SuppressWarnings("ConstantConditions")
+		ExperienceOrbEntity entity = (ExperienceOrbEntity) (Object) this;
+
+		if (MinecraftForge.EVENT_BUS.post(new PlayerPickupXpEvent(player, entity))) {
+			ci.cancel();
+		}
+	}
+}

--- a/patchwork-events-entity/src/main/resources/patchwork-events-entity.mixins.json
+++ b/patchwork-events-entity/src/main/resources/patchwork-events-entity.mixins.json
@@ -5,6 +5,7 @@
   "mixins": [
     "MixinEntity",
     "MixinEntityType",
+    "MixinExperienceOrbEntity",
     "MixinLivingEntity",
     "MixinMobEntity",
     "MixinMobSpawnerLogic",


### PR DESCRIPTION
Required for Curios, See #84.

I can't remember if it is in Forge, but I've marked `PlayerPickupXpEvent` as deprecated as it's removed in Forge for 1.15. It seems to have been the original event for interacting with XP pickups, until it was superseded by the `PlayerXpEvent` family of events.

When `PlayerXpEvent.XpChange` is cancelled, there is a very small behavioural difference to Forge: `PlayerEntity.addScore` (with zero as an argument) and `PlayerEntity.getNextLevelExperience` are called. The former calls `get` and `set` on a DataTracker, the latter doesn't call any other methods (and while other mods hooking `getNextLevelExperience` is plausible, one would expect those not to have any side-effects).

Since a `@ModifyVariable` mixin is used, it's not (as far as I know) straightforward to also properly cancel this event, though of course it can be done if you think it might make a difference.