### PR TITLE
Implement FMLServerAboutToStartEvent and hooks related to it.

### DIFF
--- a/patchwork-events-lifecycle/src/main/java/net/minecraftforge/fml/event/server/FMLServerAboutToStartEvent.java
+++ b/patchwork-events-lifecycle/src/main/java/net/minecraftforge/fml/event/server/FMLServerAboutToStartEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.event.server;
+
+import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
+
+import net.minecraft.server.MinecraftServer;
+
+/**
+ * Called before the server begins loading anything. Called after {@link InterModProcessEvent} on the dedicated
+ * server, and after the player has hit "Play Selected World" in the client. Called before {@link FMLServerStartingEvent}.
+ *
+ * <p>You can obtain a reference to the server with this event.
+ *
+ * @author cpw
+ */
+public class FMLServerAboutToStartEvent extends ServerLifecycleEvent {
+	public FMLServerAboutToStartEvent(MinecraftServer server) {
+		super(server);
+	}
+}

--- a/patchwork-events-lifecycle/src/main/java/net/minecraftforge/fml/server/ServerLifecycleHooks.java
+++ b/patchwork-events-lifecycle/src/main/java/net/minecraftforge/fml/server/ServerLifecycleHooks.java
@@ -1,0 +1,33 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.server;
+
+import net.minecraft.server.MinecraftServer;
+
+/**
+ * This is a stub of the ServerLifecycleHooks class in Forge for mods that use getCurrentServer.
+ */
+public class ServerLifecycleHooks {
+	public static MinecraftServer currentServer;
+
+	public static MinecraftServer getCurrentServer() {
+		return currentServer;
+	}
+}

--- a/patchwork-events-lifecycle/src/main/java/net/patchworkmc/impl/event/lifecycle/LifecycleEvents.java
+++ b/patchwork-events-lifecycle/src/main/java/net/patchworkmc/impl/event/lifecycle/LifecycleEvents.java
@@ -19,11 +19,19 @@
 
 package net.patchworkmc.impl.event.lifecycle;
 
+import java.nio.file.Path;
+
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fml.LogicalSidedProvider;
+import net.minecraftforge.fml.config.ConfigTracker;
+import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.event.server.FMLServerAboutToStartEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartedEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
+import net.minecraftforge.fml.loading.FileUtils;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
 
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.MinecraftServer;
@@ -59,6 +67,20 @@ public class LifecycleEvents implements ModInitializer {
 
 	public static void handleServerStarted(final MinecraftServer server) {
 		MinecraftForge.EVENT_BUS.post(new FMLServerStartedEvent(server));
+	}
+
+	public static void handleServerAboutToStart(final MinecraftServer server) {
+		ServerLifecycleHooks.currentServer = server;
+		LogicalSidedProvider.setServer(() -> server);
+		ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.SERVER, getServerConfigPath(server));
+		// TODO: ResourcePackLoader.loadResourcePacks(currentServer.getDataPackManager(), ServerLifecycleHooks::buildPackFinder);
+		MinecraftForge.EVENT_BUS.post(new FMLServerAboutToStartEvent(server));
+	}
+
+	private static Path getServerConfigPath(final MinecraftServer server) {
+		final Path serverConfig = server.getLevelStorage().resolveFile(server.getLevelName(), "serverconfig").toPath();
+		FileUtils.getOrCreateDirectory(serverConfig, "serverconfig");
+		return serverConfig;
 	}
 
 	@Override

--- a/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinIntegratedServer.java
+++ b/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinIntegratedServer.java
@@ -1,0 +1,38 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.event.lifecycle;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.integrated.IntegratedServer;
+
+import net.patchworkmc.impl.event.lifecycle.LifecycleEvents;
+
+@Mixin(IntegratedServer.class)
+public class MixinIntegratedServer {
+	@Inject(method = "setupServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/integrated/IntegratedServer;loadWorld(Ljava/lang/String;Ljava/lang/String;JLnet/minecraft/world/level/LevelGeneratorType;Lcom/google/gson/JsonElement;)V"))
+	private void onServerAboutToStart(CallbackInfoReturnable<Boolean> cir) {
+		LifecycleEvents.handleServerAboutToStart((MinecraftServer) (Object) this);
+	}
+}

--- a/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftDedicatedServer.java
+++ b/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftDedicatedServer.java
@@ -32,7 +32,7 @@ import net.patchworkmc.impl.event.lifecycle.LifecycleEvents;
 @Mixin(MinecraftDedicatedServer.class)
 public class MixinMinecraftDedicatedServer {
 	@Inject(method = "setupServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/UserCache;setUseRemote(Z)V", shift = At.Shift.AFTER))
-	private void onServerAboutToStart(CallbackInfoReturnable<Boolean> cir) {
+	private void onServerAboutToStart(CallbackInfo ci) {
 		LifecycleEvents.handleServerAboutToStart((MinecraftServer) (Object) this);
 	}
 }

--- a/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftDedicatedServer.java
+++ b/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftDedicatedServer.java
@@ -1,0 +1,38 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.event.lifecycle;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.dedicated.MinecraftDedicatedServer;
+
+import net.patchworkmc.impl.event.lifecycle.LifecycleEvents;
+
+@Mixin(MinecraftDedicatedServer.class)
+public class MixinMinecraftDedicatedServer {
+	@Inject(method = "setupServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/UserCache;setUseRemote(Z)V", shift = At.Shift.AFTER))
+	private void onServerAboutToStart(CallbackInfoReturnable<Boolean> cir) {
+		LifecycleEvents.handleServerAboutToStart((MinecraftServer) (Object) this);
+	}
+}

--- a/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftDedicatedServer.java
+++ b/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftDedicatedServer.java
@@ -22,7 +22,7 @@ package net.patchworkmc.mixin.event.lifecycle;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.dedicated.MinecraftDedicatedServer;

--- a/patchwork-events-lifecycle/src/main/resources/patchwork-events-lifecycle.mixins.json
+++ b/patchwork-events-lifecycle/src/main/resources/patchwork-events-lifecycle.mixins.json
@@ -11,6 +11,9 @@
     "MixinClientWorld",
     "MixinMinecraftClient"
   ],
+  "server": [
+    "MixinMinecraftDedicatedServer"
+  ],
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
This PR implements FMLServerAboutToStartEvent, and some other calls that happen in forge at the same time (mostly related to passing the MinecraftServer object around). It also creates a stub version of ServerLifecycleHooks that only implements getCurrentServer, which completes part of #84