### PR TITLE
Make FMLLoadCompleteEvent call at the correct time on the client.

### DIFF
--- a/patchwork-dispatcher/src/main/java/net/patchworkmc/impl/Patchwork.java
+++ b/patchwork-dispatcher/src/main/java/net/patchworkmc/impl/Patchwork.java
@@ -134,6 +134,7 @@ public class Patchwork implements ModInitializer {
 
 		dispatch(mods, InterModEnqueueEvent::new);
 		dispatch(mods, InterModProcessEvent::new);
+
 		if (FabricLoader.getInstance().getEnvironmentType() == EnvType.SERVER) {
 			dispatch(mods, FMLLoadCompleteEvent::new);
 		} else {

--- a/patchwork-dispatcher/src/main/java/net/patchworkmc/impl/Patchwork.java
+++ b/patchwork-dispatcher/src/main/java/net/patchworkmc/impl/Patchwork.java
@@ -46,7 +46,6 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.server.dedicated.DedicatedServer;
 
-import net.fabricmc.api.EnvType;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 
@@ -134,12 +133,7 @@ public class Patchwork implements ModInitializer {
 
 		dispatch(mods, InterModEnqueueEvent::new);
 		dispatch(mods, InterModProcessEvent::new);
-
-		if (FabricLoader.getInstance().getEnvironmentType() == EnvType.SERVER) {
-			dispatch(mods, FMLLoadCompleteEvent::new);
-		} else {
-			LifecycleEvents.setClientInitializedCallback(() -> dispatch(mods, FMLLoadCompleteEvent::new));
-		}
+		LifecycleEvents.setLoadCompleteCallback(() -> dispatch(mods, FMLLoadCompleteEvent::new));
 
 		MinecraftForge.EVENT_BUS.start();
 	}

--- a/patchwork-dispatcher/src/main/java/net/patchworkmc/impl/Patchwork.java
+++ b/patchwork-dispatcher/src/main/java/net/patchworkmc/impl/Patchwork.java
@@ -46,10 +46,12 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.server.dedicated.DedicatedServer;
 
+import net.fabricmc.api.EnvType;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 
 import net.patchworkmc.api.ForgeInitializer;
+import net.patchworkmc.impl.event.lifecycle.LifecycleEvents;
 import net.patchworkmc.impl.event.render.RenderEvents;
 import net.patchworkmc.impl.registries.RegistryEventDispatcher;
 
@@ -132,7 +134,11 @@ public class Patchwork implements ModInitializer {
 
 		dispatch(mods, InterModEnqueueEvent::new);
 		dispatch(mods, InterModProcessEvent::new);
-		dispatch(mods, FMLLoadCompleteEvent::new);
+		if (FabricLoader.getInstance().getEnvironmentType() == EnvType.SERVER) {
+			dispatch(mods, FMLLoadCompleteEvent::new);
+		} else {
+			LifecycleEvents.setClientInitializedCallback(() -> dispatch(mods, FMLLoadCompleteEvent::new));
+		}
 
 		MinecraftForge.EVENT_BUS.start();
 	}

--- a/patchwork-events-lifecycle/src/main/java/net/patchworkmc/impl/event/lifecycle/LifecycleEvents.java
+++ b/patchwork-events-lifecycle/src/main/java/net/patchworkmc/impl/event/lifecycle/LifecycleEvents.java
@@ -42,7 +42,7 @@ import net.fabricmc.fabric.api.event.server.ServerStartCallback;
 import net.fabricmc.fabric.api.event.world.WorldTickCallback;
 
 public class LifecycleEvents implements ModInitializer {
-	private static Runnable clientLoadCallback;
+	private static Runnable loadCompleteCallback;
 
 	public static void fireWorldTickEvent(TickEvent.Phase phase, World world) {
 		LogicalSide side = world.isClient() ? LogicalSide.CLIENT : LogicalSide.SERVER;
@@ -85,12 +85,12 @@ public class LifecycleEvents implements ModInitializer {
 		return serverConfig;
 	}
 
-	public static void setClientInitializedCallback(Runnable callback) {
-		clientLoadCallback = callback;
+	public static void setLoadCompleteCallback(Runnable callback) {
+		loadCompleteCallback = callback;
 	}
 
-	public static void onClientInitialized() {
-		clientLoadCallback.run();
+	public static void handleLoadComplete() {
+		loadCompleteCallback.run();
 	}
 
 	@Override

--- a/patchwork-events-lifecycle/src/main/java/net/patchworkmc/impl/event/lifecycle/LifecycleEvents.java
+++ b/patchwork-events-lifecycle/src/main/java/net/patchworkmc/impl/event/lifecycle/LifecycleEvents.java
@@ -42,6 +42,8 @@ import net.fabricmc.fabric.api.event.server.ServerStartCallback;
 import net.fabricmc.fabric.api.event.world.WorldTickCallback;
 
 public class LifecycleEvents implements ModInitializer {
+	private static Runnable clientLoadCallback;
+
 	public static void fireWorldTickEvent(TickEvent.Phase phase, World world) {
 		LogicalSide side = world.isClient() ? LogicalSide.CLIENT : LogicalSide.SERVER;
 		TickEvent.WorldTickEvent event = new TickEvent.WorldTickEvent(side, phase, world);
@@ -81,6 +83,14 @@ public class LifecycleEvents implements ModInitializer {
 		final Path serverConfig = server.getLevelStorage().resolveFile(server.getLevelName(), "serverconfig").toPath();
 		FileUtils.getOrCreateDirectory(serverConfig, "serverconfig");
 		return serverConfig;
+	}
+
+	public static void setClientInitializedCallback(Runnable callback) {
+		clientLoadCallback = callback;
+	}
+
+	public static void onClientInitialized() {
+		clientLoadCallback.run();
 	}
 
 	@Override

--- a/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftClient.java
+++ b/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftClient.java
@@ -29,6 +29,8 @@ import net.minecraftforge.event.TickEvent;
 
 import net.minecraft.client.MinecraftClient;
 
+import net.patchworkmc.impl.event.lifecycle.LifecycleEvents;
+
 @Mixin(MinecraftClient.class)
 public class MixinMinecraftClient {
 	// If this used HEAD, it doesn't run at exactly the same time as in Forge - itemUseCooldown
@@ -46,5 +48,10 @@ public class MixinMinecraftClient {
 	private void hookClientTickEnd(CallbackInfo info) {
 		TickEvent.ClientTickEvent event = new TickEvent.ClientTickEvent(TickEvent.Phase.END);
 		MinecraftForge.EVENT_BUS.post(event);
+	}
+
+	@Inject(method = "init", at = @At("RETURN"))
+	private void hookClientInit(CallbackInfo ci) {
+		LifecycleEvents.onClientInitialized();
 	}
 }

--- a/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftClient.java
+++ b/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftClient.java
@@ -52,6 +52,6 @@ public class MixinMinecraftClient {
 
 	@Inject(method = "init", at = @At("RETURN"))
 	private void hookClientInit(CallbackInfo ci) {
-		LifecycleEvents.onClientInitialized();
+		LifecycleEvents.handleLoadComplete();
 	}
 }

--- a/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftDedicatedServer.java
+++ b/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftDedicatedServer.java
@@ -33,6 +33,7 @@ import net.patchworkmc.impl.event.lifecycle.LifecycleEvents;
 public class MixinMinecraftDedicatedServer {
 	@Inject(method = "setupServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/UserCache;setUseRemote(Z)V", shift = At.Shift.AFTER))
 	private void onServerAboutToStart(CallbackInfo ci) {
+		LifecycleEvents.handleLoadComplete(); // This is a "multithreaded" event that would be called around this time.
 		LifecycleEvents.handleServerAboutToStart((MinecraftServer) (Object) this);
 	}
 }


### PR DESCRIPTION
This PR fixes #85 by calling FMLLoadCompleteEvent after MinecraftClient.init() is completed.