### PR TITLE
Implement the LivingDropsEvent event

### DIFF
--- a/patchwork-events-entity/build.gradle
+++ b/patchwork-events-entity/build.gradle
@@ -3,5 +3,6 @@ version = getSubprojectVersion(project, "0.3.0")
 
 dependencies {
 	compile project(path: ':patchwork-fml', configuration: 'dev')
+	compile project(path: ':patchwork-extensions', configuration: 'dev')
 	compile project(path: ':patchwork-extensions-item', configuration: 'dev')
 }

--- a/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/living/LivingDropsEvent.java
+++ b/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/living/LivingDropsEvent.java
@@ -1,0 +1,83 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.living;
+
+import java.util.Collection;
+
+import net.minecraftforge.common.MinecraftForge;
+
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+
+/**
+ * LivingDropsEvent is fired when an Entity's death causes dropped items to appear.
+ *
+ * <p>This event is fired whenever an Entity dies and drops items in {@link LivingEntity#onDeath(DamageSource)}.</p>
+ *
+ * <p>
+ * {@link #source} contains the DamageSource that caused the drop to occur.<br>
+ * {@link #drops} contains the ArrayList of EntityItems that will be dropped.<br>
+ * {@link #lootingLevel} contains the amount of loot that will be dropped.<br>
+ * {@link #recentlyHit} determines whether the Entity doing the drop has recently been damaged.<br>
+ * </p>
+ *
+ * <p>This event is cancelable. If this event is canceled, the Entity does not drop anything.</p>
+ *
+ * <p>This event does not have a result.</p>
+ *
+ * <p>This event is fired on the {@link MinecraftForge#EVENT_BUS}.</p>
+ */
+public class LivingDropsEvent extends LivingEvent {
+	private final DamageSource source;
+	private final Collection<ItemEntity> drops;
+	private final int lootingLevel;
+	private final boolean recentlyHit;
+
+	public LivingDropsEvent(LivingEntity entity, DamageSource source, Collection<ItemEntity> drops, int lootingLevel, boolean recentlyHit) {
+		super(entity);
+		this.source = source;
+		this.drops = drops;
+		this.lootingLevel = lootingLevel;
+		this.recentlyHit = recentlyHit;
+	}
+
+	public DamageSource getSource() {
+		return source;
+	}
+
+	public Collection<ItemEntity> getDrops() {
+		return drops;
+	}
+
+	public int getLootingLevel() {
+		return lootingLevel;
+	}
+
+	public boolean isRecentlyHit() {
+		return recentlyHit;
+	}
+
+	@Override
+	public boolean isCancelable() {
+		return true;
+	}
+}
+

--- a/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/living/LivingDropsEvent.java
+++ b/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/living/LivingDropsEvent.java
@@ -33,10 +33,10 @@ import net.minecraft.entity.damage.DamageSource;
  * <p>This event is fired whenever an Entity dies and drops items in {@link LivingEntity#onDeath(DamageSource)}.</p>
  *
  * <p>
- * {@link #source} contains the DamageSource that caused the drop to occur.<br>
- * {@link #drops} contains the ArrayList of EntityItems that will be dropped.<br>
- * {@link #lootingLevel} contains the amount of loot that will be dropped.<br>
- * {@link #recentlyHit} determines whether the Entity doing the drop has recently been damaged.<br>
+ * {@link #source} contains the {@link DamageSource} that caused the drop to occur.<br>
+ * {@link #drops} contains the Collection of {@link ItemEntity}s that will be dropped.<br>
+ * {@link #lootingLevel} contains the level of Looting used to kill the entity doing the drop.<br>
+ * {@link #recentlyHit} determines whether the entity doing the drop has recently been damaged by a player or tamed wolf.<br>
  * </p>
  *
  * <p>This event is cancelable. If this event is canceled, the Entity does not drop anything.</p>

--- a/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinLivingEntity.java
+++ b/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinLivingEntity.java
@@ -133,8 +133,8 @@ public class MixinLivingEntity {
 	 * }</pre>
 	 *
 	 * And thus we can't access the looting level from the end since it's local has
-	 * been discarded. Thus we store it in a field, with an atomic reference to the
-	 * thread currently using it to prevent silent corruption.
+	 * been discarded. Thus we store it in a ThreadLocal, to keep track of it between
+	 * the two methods.
 	 * </p>
 	 */
 	@Unique

--- a/patchwork-extensions/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/patchwork-extensions/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -1,0 +1,38 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.extensions;
+
+import java.util.Collection;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.ItemEntity;
+
+public interface IForgeEntity {
+	default Entity getEntity() {
+		return (Entity) this;
+	}
+
+	@Nullable
+	Collection<ItemEntity> captureDrops();
+
+	Collection<ItemEntity> captureDrops(@Nullable Collection<ItemEntity> captureDrops);
+}

--- a/patchwork-extensions/src/main/java/net/patchworkmc/mixin/extension/MixinEntity.java
+++ b/patchwork-extensions/src/main/java/net/patchworkmc/mixin/extension/MixinEntity.java
@@ -1,0 +1,66 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.extension;
+
+import java.util.Collection;
+
+import javax.annotation.Nullable;
+
+import net.minecraftforge.common.extensions.IForgeEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.world.World;
+
+@Mixin(Entity.class)
+public class MixinEntity implements IForgeEntity {
+	@Unique
+	private Collection<ItemEntity> captureDrops = null;
+
+	@Redirect(method = "dropStack(Lnet/minecraft/item/ItemStack;F)Lnet/minecraft/entity/ItemEntity;",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnEntity(Lnet/minecraft/entity/Entity;)Z"))
+	private boolean hookDropStackForCapture(World world, Entity entity) {
+		ItemEntity itemEntity = (ItemEntity) entity;
+
+		if (captureDrops() != null) {
+			captureDrops().add(itemEntity);
+			return true;
+		} else {
+			return world.spawnEntity(itemEntity);
+		}
+	}
+
+	@Nullable
+	@Override
+	public Collection<ItemEntity> captureDrops() {
+		return captureDrops;
+	}
+
+	@Override
+	public Collection<ItemEntity> captureDrops(@Nullable Collection<ItemEntity> value) {
+		Collection<ItemEntity> ret = captureDrops;
+		this.captureDrops = value;
+		return ret;
+	}
+}

--- a/patchwork-extensions/src/main/java/net/patchworkmc/mixin/extension/MixinServerPlayerEntity.java
+++ b/patchwork-extensions/src/main/java/net/patchworkmc/mixin/extension/MixinServerPlayerEntity.java
@@ -1,0 +1,47 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.extension;
+
+import net.minecraftforge.common.extensions.IForgeEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.world.World;
+
+@Mixin(ServerPlayerEntity.class)
+public class MixinServerPlayerEntity {
+	@Redirect(method = "dropItem(Lnet/minecraft/item/ItemStack;ZZ)Lnet/minecraft/entity/ItemEntity;",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnEntity(Lnet/minecraft/entity/Entity;)Z"))
+	private boolean hookDropItemForCapture(World world, Entity entity) {
+		ItemEntity itemEntity = (ItemEntity) entity;
+		IForgeEntity forgeEntity = (IForgeEntity) this;
+
+		if (forgeEntity.captureDrops() != null) {
+			forgeEntity.captureDrops().add(itemEntity);
+			return true;
+		} else {
+			return world.spawnEntity(itemEntity);
+		}
+	}
+}

--- a/patchwork-extensions/src/main/resources/patchwork-extensions.mixins.json
+++ b/patchwork-extensions/src/main/resources/patchwork-extensions.mixins.json
@@ -3,8 +3,10 @@
   "package": "net.patchworkmc.mixin.extension",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "MixinEntity",
     "MixinEntityType",
     "MixinEntityTypeBuilder",
+    "MixinServerPlayerEntity",
     "MixinStatusEffect"
   ],
   "injectors": {


### PR DESCRIPTION
Required for Curios, see #84.

This PR is largely comprised of two parts:

Firstly, it implements `Entity.captureDrops` in the `patchwork-extensions` module. This is a collection that can be set on an entity that will redirect all the `ItemEntity`s it would otherwise drop on the ground into said collection.

The second part (in the second commit) adds to `LivingEntity` to use this mechanism to catch all the items the LivingEntity drops when it dies, and pass it through an event to let mods alter the dropped items. Finally it spawns them if the event wasn't cancelled.

Note that the second part creates a dependency from `patchwork-events-entity` to `patchwork-extensions`, however it seemed like the most logical place to put both parts.

The second part does involve some hackery to access the looting level after the local variable has been dropped, passing it through a field (described in a JavaDoc comment). I could just call `EnchantmentHelper.getLooting` again, but we'd have to use this method anyway when we implement `LootingLevelEvent`.