### PR TITLE
Add ExtensionPoint to prevent one-sided mods from crashing

### DIFF
--- a/patchwork-fml/src/main/java/net/minecraftforge/fml/ExtensionPoint.java
+++ b/patchwork-fml/src/main/java/net/minecraftforge/fml/ExtensionPoint.java
@@ -1,0 +1,55 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml;
+
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Supplier;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+
+public class ExtensionPoint<T> {
+	public static final ExtensionPoint<BiFunction<MinecraftClient, Screen, Screen>> CONFIGGUIFACTORY = new ExtensionPoint<>();
+	// TODO: Not used by any Forge code, ModFileResourcePack is not implemented in Patchwork API
+	// public static final ExtensionPoint<BiFunction<MinecraftClient, ModFileResourcePack, ResourcePack>> RESOURCEPACK = new ExtensionPoint<>();
+	/**
+	 * Compatibility display test for the mod. Used for displaying compatibility
+	 * with remote servers with the same mod, and on disk saves.
+	 *
+	 * <p>The supplier provides my "local" version for sending across the network or
+	 * writing to disk The predicate tests the version from a remote instance or
+	 * save for acceptability (Boolean is true for network, false for local save)
+	 *
+	 * <p>TODO: Fabric servers do not check for client's mod list,
+	 * there is no way to implement the DISPLAYTEST function in Patchwork.
+	 * A Server-side Forge mod will not know if a client does not have it.
+	 * Currently, this method is here purely for avoiding {@link java.lang.ClassNotFoundException}
+	 */
+	public static final ExtensionPoint<Pair<Supplier<String>, BiPredicate<String, Boolean>>> DISPLAYTEST = new ExtensionPoint<>();
+
+	// Forge's unused private field
+	// private Class<T> type;
+
+	private ExtensionPoint() {
+	}
+}

--- a/patchwork-fml/src/main/java/net/minecraftforge/fml/ExtensionPoint.java
+++ b/patchwork-fml/src/main/java/net/minecraftforge/fml/ExtensionPoint.java
@@ -36,8 +36,8 @@ public class ExtensionPoint<T> {
 	 * Compatibility display test for the mod. Used for displaying compatibility
 	 * with remote servers with the same mod, and on disk saves.
 	 *
-	 * <p>The supplier provides my "local" version for sending across the network or
-	 * writing to disk The predicate tests the version from a remote instance or
+	 * <p>The supplier provides the "local" version for sending across the network or
+	 * writing to disk. The predicate tests the version from a remote instance or
 	 * save for acceptability (Boolean is true for network, false for local save)
 	 *
 	 * <p>TODO: Fabric servers do not check for client's mod list,

--- a/patchwork-fml/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/patchwork-fml/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -20,14 +20,22 @@
 package net.minecraftforge.fml;
 
 import java.util.EnumMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.config.ModConfig;
 
 // TODO: Stub
 public abstract class ModContainer {
+	protected static final Logger LOGGER = LogManager.getLogger(ModContainer.class);
 	protected final String modId;
 	protected final String namespace;
+	protected final Map<ExtensionPoint, Supplier<?>> extensionPoints = new IdentityHashMap<>();
 	protected final EnumMap<ModConfig.Type, ModConfig> configs;
 	private net.fabricmc.loader.api.ModContainer fabricModContainer;
 
@@ -44,6 +52,21 @@ public abstract class ModContainer {
 
 	public final String getNamespace() {
 		return namespace;
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T> Optional<T> getCustomExtension(ExtensionPoint<T> point) {
+		return Optional.ofNullable((T) extensionPoints.getOrDefault(point, () -> null).get());
+	}
+
+	public <T> void registerExtensionPoint(ExtensionPoint<T> point, Supplier<T> extension) {
+		extensionPoints.put(point, extension);
+
+		if (point == ExtensionPoint.DISPLAYTEST) {
+			LOGGER.warn(
+					"ExtensionPoint.DISPLAYTEST is not handled by Patchwork due to the limitation of Fabric, "
+					+ "we cannot prevent loading mods at wrong side or incompatible versions!");
+		}
 	}
 
 	public void addConfig(final ModConfig modConfig) {

--- a/patchwork-fml/src/main/java/net/minecraftforge/fml/ModLoadingContext.java
+++ b/patchwork-fml/src/main/java/net/minecraftforge/fml/ModLoadingContext.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.fml;
 
+import java.util.function.Supplier;
+
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.fml.config.ModConfig;
 
@@ -50,6 +52,17 @@ public class ModLoadingContext {
 		} else {
 			return activeContainer.getNamespace();
 		}
+	}
+
+	/**
+	 * Register an {@link ExtensionPoint} with the mod container.
+	 *
+	 * @param point     The extension point to register
+	 * @param extension An extension operator
+	 * @param           <T> The type signature of the extension operator
+	 */
+	public <T> void registerExtensionPoint(ExtensionPoint<T> point, Supplier<T> extension) {
+		getActiveContainer().registerExtensionPoint(point, extension);
 	}
 
 	public void registerConfig(ModConfig.Type type, ForgeConfigSpec spec) {

--- a/patchwork-networking/src/main/java/net/minecraftforge/fml/network/FMLNetworkConstants.java
+++ b/patchwork-networking/src/main/java/net/minecraftforge/fml/network/FMLNetworkConstants.java
@@ -1,0 +1,37 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.network;
+
+/**
+ * Constants related to networking.
+ */
+public class FMLNetworkConstants {
+	public static final String FMLNETMARKER = "FML";
+	public static final int FMLNETVERSION = 2;
+	public static final String NETVERSION = FMLNETMARKER + FMLNETVERSION;
+	public static final String NOVERSION = "NONE";
+
+	/**
+	 * Return this value in your
+	 * {@link net.minecraftforge.fml.ExtensionPoint#DISPLAYTEST} function to be
+	 * ignored.
+	 */
+	public static final String IGNORESERVERONLY = "OHNOES\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31\uD83D\uDE31";
+}


### PR DESCRIPTION
In 1.14, Forge removed “sidedness” attribute from the `mods.toml` and now one-side mods have to call this in their mod constructor to skip side checking:
```java
//Make sure the mod being absent on the other network side does not cause the client to display the server as incompatible
ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () -> Pair.of(() -> FMLNetworkConstants.IGNORESERVERONLY, (a, b) -> true));
```

This pr adds `ExtensionPoint.DISPLAYTEST` and relevent ExtensionPoint functions. However, due to a limitation of the Fabric Loader, Patchwork will not check for the presence of the Forge mod on the other side.