### PR TITLE
Add LootTableLoadEvent, methods on LootPool/LootTable

### DIFF
--- a/patchwork-events-lifecycle/src/main/java/net/minecraftforge/fml/event/server/FMLServerStoppedEvent.java
+++ b/patchwork-events-lifecycle/src/main/java/net/minecraftforge/fml/event/server/FMLServerStoppedEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.event.server;
+
+import net.minecraft.server.MinecraftServer;
+
+/**
+ * Called after {@link FMLServerStoppingEvent} when the server has completely shut down.
+ * Called immediately before shutting down, on the dedicated server, and before returning
+ * to the main menu on the client.
+ *
+ * @author cpw
+ */
+public class FMLServerStoppedEvent extends ServerLifecycleEvent {
+	public FMLServerStoppedEvent(MinecraftServer server) {
+		super(server);
+	}
+}

--- a/patchwork-events-lifecycle/src/main/java/net/minecraftforge/fml/server/ServerLifecycleHooks.java
+++ b/patchwork-events-lifecycle/src/main/java/net/minecraftforge/fml/server/ServerLifecycleHooks.java
@@ -51,4 +51,8 @@ public class ServerLifecycleHooks {
 	public static void handleServerStarted(final MinecraftServer server) {
 		LifecycleEvents.handleServerStarted(server);
 	}
+
+	public static void handleServerStopped(final MinecraftServer server) {
+		LifecycleEvents.handleServerStopped(server);
+	}
 }

--- a/patchwork-events-lifecycle/src/main/java/net/minecraftforge/fml/server/ServerLifecycleHooks.java
+++ b/patchwork-events-lifecycle/src/main/java/net/minecraftforge/fml/server/ServerLifecycleHooks.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.fml.server;
 
+import java.util.concurrent.CountDownLatch;
+
 import net.minecraft.server.MinecraftServer;
 
 import net.patchworkmc.impl.event.lifecycle.LifecycleEvents;
@@ -28,6 +30,7 @@ import net.patchworkmc.impl.event.lifecycle.LifecycleEvents;
  */
 public class ServerLifecycleHooks {
 	public static MinecraftServer currentServer;
+	public static volatile CountDownLatch exitLatch = null;
 
 	public static MinecraftServer getCurrentServer() {
 		return currentServer;

--- a/patchwork-events-lifecycle/src/main/java/net/patchworkmc/impl/event/lifecycle/LifecycleEvents.java
+++ b/patchwork-events-lifecycle/src/main/java/net/patchworkmc/impl/event/lifecycle/LifecycleEvents.java
@@ -20,6 +20,7 @@
 package net.patchworkmc.impl.event.lifecycle;
 
 import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
 
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
@@ -30,6 +31,7 @@ import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.server.FMLServerAboutToStartEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartedEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
+import net.minecraftforge.fml.event.server.FMLServerStoppedEvent;
 import net.minecraftforge.fml.loading.FileUtils;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
 
@@ -91,6 +93,18 @@ public class LifecycleEvents implements ModInitializer {
 
 	public static void handleLoadComplete() {
 		loadCompleteCallback.run();
+	}
+
+	public static void handleServerStopped(final MinecraftServer server) {
+		MinecraftForge.EVENT_BUS.post(new FMLServerStoppedEvent(server));
+		ServerLifecycleHooks.currentServer = null;
+		LogicalSidedProvider.setServer(null);
+		CountDownLatch latch = ServerLifecycleHooks.exitLatch;
+
+		if (latch != null) {
+			latch.countDown();
+			ServerLifecycleHooks.exitLatch = null;
+		}
 	}
 
 	@Override

--- a/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftServer.java
+++ b/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftServer.java
@@ -31,7 +31,7 @@ import net.patchworkmc.impl.event.lifecycle.LifecycleEvents;
 @Mixin(MinecraftServer.class)
 public class MixinMinecraftServer {
 	@Inject(method = "run", at = @At(value = "INVOKE", target = "net/minecraft/server/MinecraftServer.exit ()V"))
-	void serverStoppedHook(CallbackInfo ci) {
+	private void serverStoppedHook(CallbackInfo ci) {
 		LifecycleEvents.handleServerStopped((MinecraftServer) (Object) this);
 	}
 }

--- a/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftServer.java
+++ b/patchwork-events-lifecycle/src/main/java/net/patchworkmc/mixin/event/lifecycle/MixinMinecraftServer.java
@@ -1,0 +1,37 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.event.lifecycle;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.server.MinecraftServer;
+
+import net.patchworkmc.impl.event.lifecycle.LifecycleEvents;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+	@Inject(method = "run", at = @At(value = "INVOKE", target = "net/minecraft/server/MinecraftServer.exit ()V"))
+	void serverStoppedHook(CallbackInfo ci) {
+		LifecycleEvents.handleServerStopped((MinecraftServer) (Object) this);
+	}
+}

--- a/patchwork-god-classes/build.gradle
+++ b/patchwork-god-classes/build.gradle
@@ -7,4 +7,5 @@ dependencies {
 	compile project(path: ':patchwork-events-entity', configuration: 'dev')
 	compile project(path: ':patchwork-events-lifecycle', configuration: 'dev')
 	compile project(path: ':patchwork-events-rendering', configuration: 'dev')
+	compile project(path: ':patchwork-loot', configuration: 'dev')
 }

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -23,6 +23,8 @@ import java.util.Collection;
 
 import javax.annotation.Nullable;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.eventbus.api.Event;
 
@@ -33,12 +35,16 @@ import net.minecraft.entity.SpawnType;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.loot.LootManager;
+import net.minecraft.loot.LootTable;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.Identifier;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.MobSpawnerLogic;
 
 import net.patchworkmc.impl.event.entity.EntityEvents;
+import net.patchworkmc.impl.loot.LootHooks;
 
 /*
  * Note: this class is intended for mod use only, to dispatch to the implementations kept in their own modules.
@@ -97,5 +103,14 @@ public class ForgeHooks {
 
 	public static boolean onPlayerAttackTarget(PlayerEntity player, Entity target) {
 		return EntityEvents.attackEntity(player, target);
+	}
+
+	@Nullable
+	public static LootTable loadLootTable(Gson gson, Identifier name, JsonObject data, boolean custom, LootManager lootTableManager) {
+		return LootHooks.loadLootTable(gson, name, data, custom, lootTableManager);
+	}
+
+	public static String readPoolName(JsonObject json) {
+		return LootHooks.readPoolName(json);
 	}
 }

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -28,12 +28,16 @@ import net.minecraftforge.eventbus.api.Event;
 import net.minecraft.entity.SpawnType;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.loot.LootManager;
+import net.minecraft.loot.LootTable;
+import net.minecraft.util.Identifier;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.MobSpawnerLogic;
 import net.minecraft.world.World;
 
 import net.patchworkmc.impl.capability.CapabilityEvents;
 import net.patchworkmc.impl.event.entity.EntityEvents;
+import net.patchworkmc.impl.event.loot.LootEvents;
 
 /*
  * Note: this class is intended for mod use only, to dispatch to the implementations kept in their own modules.
@@ -64,5 +68,9 @@ public class ForgeEventFactory {
 
 	public static boolean doSpecialSpawn(MobEntity entity, World world, float x, float y, float z, MobSpawnerLogic spawner, SpawnType spawnReason) {
 		return EntityEvents.doSpecialSpawn(entity, world, x, y, z, spawner, spawnReason);
+	}
+
+	public static LootTable loadLootTable(Identifier name, LootTable table, LootManager lootTableManager) {
+		return LootEvents.loadLootTable(name, table, lootTableManager);
 	}
 }

--- a/patchwork-god-classes/src/main/resources/fabric.mod.json
+++ b/patchwork-god-classes/src/main/resources/fabric.mod.json
@@ -19,7 +19,8 @@
     "patchwork-fml": "*",
     "patchwork-capabilities": "*",
     "patchwork-events-lifecycle": "*",
-    "patchwork-events-rendering": "*"
+    "patchwork-events-rendering": "*",
+    "patchwork-loot": "*"
   },
   "custom": {
     "modmenu:api": true,

--- a/patchwork-loot/build.gradle
+++ b/patchwork-loot/build.gradle
@@ -1,2 +1,7 @@
 archivesBaseName = "patchwork-loot"
 version = getSubprojectVersion(project, "0.2.0")
+
+dependencies {
+	compile project(path: ':patchwork-fml', configuration: 'dev')
+}
+

--- a/patchwork-loot/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
+++ b/patchwork-loot/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
@@ -1,0 +1,67 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event;
+
+import net.minecraftforge.eventbus.api.Event;
+
+import net.minecraft.loot.LootManager;
+import net.minecraft.loot.LootTable;
+import net.minecraft.util.Identifier;
+
+/**
+ * Event fired when a LootTable json is loaded from json.
+ * This event is fired whenever resources are loaded, or when the server starts.
+ * This event will NOT be fired for LootTables loaded from the world folder, these are
+ * considered configurations files and should not be modified by mods.
+ *
+ * <p>Canceling the event will make it load a empty loot table.</p>
+ */
+public class LootTableLoadEvent extends Event {
+	private final Identifier name;
+	private LootTable table;
+	private LootManager lootTableManager;
+
+	public LootTableLoadEvent(Identifier name, LootTable table, LootManager lootTableManager) {
+		this.name = name;
+		this.table = table;
+		this.lootTableManager = lootTableManager;
+	}
+
+	public Identifier getName() {
+		return this.name;
+	}
+
+	public LootTable getTable() {
+		return this.table;
+	}
+
+	public void setTable(LootTable table) {
+		this.table = table;
+	}
+
+	public LootManager getLootTableManager() {
+		return this.lootTableManager;
+	}
+
+	@Override
+	public boolean isCancelable() {
+		return true;
+	}
+}

--- a/patchwork-loot/src/main/java/net/patchworkmc/api/loot/ForgeLootPool.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/api/loot/ForgeLootPool.java
@@ -1,0 +1,42 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.api.loot;
+
+import net.minecraft.loot.LootPool;
+import net.minecraft.loot.LootTableRange;
+import net.minecraft.loot.UniformLootTableRange;
+
+/**
+ * Interface for adding Forge methods added to LootPool and its inner classes.
+ */
+public interface ForgeLootPool {
+	// TODO: doesn't include methods having to do with freezing yet
+
+	String getName();
+	LootTableRange getRolls();
+	LootTableRange getBonusRolls();
+	void setRolls(UniformLootTableRange v);
+	void setBonusRolls(UniformLootTableRange v);
+
+	public interface Builder {
+		LootPool.Builder name(String name);
+		LootPool.Builder bonusRolls(float min, float max);
+	}
+}

--- a/patchwork-loot/src/main/java/net/patchworkmc/api/loot/ForgeLootTable.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/api/loot/ForgeLootTable.java
@@ -1,0 +1,33 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.api.loot;
+
+import net.minecraft.loot.LootPool;
+
+/**
+ * Interface for adding Forge methods added to LootTable.
+ */
+public interface ForgeLootTable {
+	// TODO: doesn't include methods having to do with freezing yet
+
+	LootPool getPool(String name);
+	LootPool removePool(String name);
+	void addPool(LootPool pool);
+}

--- a/patchwork-loot/src/main/java/net/patchworkmc/impl/event/loot/LootEvents.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/impl/event/loot/LootEvents.java
@@ -1,0 +1,39 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.impl.event.loot;
+
+import net.minecraftforge.event.LootTableLoadEvent;
+import net.minecraftforge.common.MinecraftForge;
+
+import net.minecraft.loot.LootManager;
+import net.minecraft.loot.LootTable;
+import net.minecraft.util.Identifier;
+
+public class LootEvents {
+	public static LootTable loadLootTable(Identifier name, LootTable table, LootManager manager) {
+		LootTableLoadEvent event = new LootTableLoadEvent(name, table, manager);
+
+		if (MinecraftForge.EVENT_BUS.post(event)) {
+			return LootTable.EMPTY;
+		}
+
+		return event.getTable();
+	}
+}

--- a/patchwork-loot/src/main/java/net/patchworkmc/impl/loot/LootHooks.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/impl/loot/LootHooks.java
@@ -1,0 +1,148 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.impl.loot;
+
+import java.util.Deque;
+import java.util.HashSet;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.Queues;
+import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import org.spongepowered.asm.mixin.Unique;
+
+import net.minecraft.loot.LootManager;
+import net.minecraft.loot.LootTable;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+
+import net.patchworkmc.impl.event.loot.LootEvents;
+
+public class LootHooks {
+	@Unique
+	private static ThreadLocal<Deque<LootTableContext>> lootContext = new ThreadLocal<Deque<LootTableContext>>();
+
+	public static LootTable loadLootTable(Gson gson, Identifier name, JsonElement data, boolean custom, LootManager lootTableManager) {
+		Deque<LootTableContext> que = lootContext.get();
+
+		if (que == null) {
+			que = Queues.newArrayDeque();
+			lootContext.set(que);
+		}
+
+		LootTable ret = null;
+
+		try {
+			que.push(new LootTableContext(name, custom));
+			ret = gson.fromJson(data, LootTable.class);
+			que.pop();
+		} catch (JsonParseException e) {
+			que.pop();
+			throw e;
+		}
+
+		if (!custom) {
+			ret = LootEvents.loadLootTable(name, ret, lootTableManager);
+		}
+
+		// if (ret != null) {
+		// 	ret.freeze();
+		// }
+
+		return ret;
+	}
+
+	private static LootTableContext getLootTableContext() {
+		LootTableContext ctx = lootContext.get().peek();
+
+		if (ctx == null) {
+			throw new JsonParseException("Invalid call stack, could not grab json context!"); // Should I throw this? Do we care about custom deserializers outside the manager?
+		}
+
+		return ctx;
+	}
+
+	public static String readPoolName(JsonObject json) {
+		LootTableContext ctx = LootHooks.getLootTableContext();
+		ctx.resetPoolCtx();
+
+		if (json.has("name")) {
+			return JsonHelper.getString(json, "name");
+		}
+
+		if (ctx.custom) {
+			return "custom#" + json.hashCode(); //We don't care about custom ones modders shouldn't be editing them!
+		}
+
+		ctx.poolCount++;
+
+		if (!ctx.vanilla) {
+			throw new JsonParseException("Loot Table \"" + ctx.name.toString() + "\" Missing `name` entry for pool #" + (ctx.poolCount - 1));
+		}
+
+		return ctx.poolCount == 1 ? "main" : "pool" + (ctx.poolCount - 1);
+	}
+
+	private static class LootTableContext {
+		public final Identifier name;
+		public final boolean custom;
+		private final boolean vanilla;
+		public int poolCount = 0;
+		public int entryCount = 0;
+		private HashSet<String> entryNames = Sets.newHashSet();
+
+		private LootTableContext(Identifier name, boolean custom) {
+			this.name = name;
+			this.custom = custom;
+			this.vanilla = "minecraft".equals(this.name.getNamespace());
+		}
+
+		private void resetPoolCtx() {
+			this.entryCount = 0;
+			this.entryNames.clear();
+		}
+
+		public String validateEntryName(@Nullable String name) {
+			if (name != null && !this.entryNames.contains(name)) {
+				this.entryNames.add(name);
+				return name;
+			}
+
+			if (!this.vanilla) {
+				throw new JsonParseException("Loot Table \"" + this.name.toString() + "\" Duplicate entry name \"" + name + "\" for pool #" + (this.poolCount - 1) + " entry #" + (this.entryCount - 1));
+			}
+
+			int x = 0;
+
+			while (this.entryNames.contains(name + "#" + x)) {
+				x++;
+			}
+
+			name = name + "#" + x;
+			this.entryNames.add(name);
+
+			return name;
+		}
+	}
+}

--- a/patchwork-loot/src/main/java/net/patchworkmc/impl/loot/LootHooks.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/impl/loot/LootHooks.java
@@ -39,6 +39,7 @@ import net.minecraft.util.JsonHelper;
 
 import net.patchworkmc.impl.event.loot.LootEvents;
 
+// NOTE: this class is more or less a direct copy of parts of Forge's ForgeHooks.
 public class LootHooks {
 	@Unique
 	private static ThreadLocal<Deque<LootTableContext>> lootContext = new ThreadLocal<Deque<LootTableContext>>();

--- a/patchwork-loot/src/main/java/net/patchworkmc/impl/loot/PatchworkLootPool.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/impl/loot/PatchworkLootPool.java
@@ -1,0 +1,28 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.impl.loot;
+
+/**
+ * Forge does this through patching the constructor, we just add methods with
+ * mixins instead.
+ */
+public interface PatchworkLootPool {
+	void patchwork$setName(String name);
+}

--- a/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinJsonDataLoader.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinJsonDataLoader.java
@@ -1,0 +1,44 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.loot;
+
+import java.util.Map;
+
+import com.google.gson.JsonObject;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.resource.JsonDataLoader;
+import net.minecraft.resource.SinglePreparationResourceReloadListener;
+import net.minecraft.util.Identifier;
+
+// TODO: Is there a better place to put this?
+@Mixin(JsonDataLoader.class)
+public abstract class MixinJsonDataLoader extends SinglePreparationResourceReloadListener<Map<Identifier, JsonObject>> {
+	@Shadow
+	@Final
+	String dataType;
+
+	// This does not get its own interface -- any mixins on subclasses wishing to use it should probably extend this mixin.
+	protected Identifier getPreparedPath(Identifier id) {
+		return new Identifier(id.getNamespace(), dataType + "/" + id.getPath() + ".json");
+	}
+}

--- a/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootManager.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootManager.java
@@ -28,6 +28,7 @@ import com.google.gson.JsonObject;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -71,5 +72,10 @@ public abstract class MixinLootManager extends MixinJsonDataLoader {
 				LOGGER.error("Couldn't parse loot table {}", id, ex);
 			}
 		});
+	}
+
+	@Overwrite
+	private static void method_20711(ImmutableMap.Builder<Identifier, LootTable> builder, Identifier id, JsonObject obj) {
+		// We are effectively overwriting this lambda with our own, so let's make that explicit by actually overwriting it.
 	}
 }

--- a/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootManager.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootManager.java
@@ -1,0 +1,89 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.loot;
+
+import java.io.IOException;
+import java.util.Deque;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Queues;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.loot.LootManager;
+import net.minecraft.resource.Resource;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.profiler.Profiler;
+
+import net.patchworkmc.impl.loot.LootHooks;
+
+@Mixin(LootManager.class)
+public abstract class MixinLootManager extends MixinJsonDataLoader {
+	// should this also be part of the static threadlocal?
+	@Unique
+	private ResourceManager resourceManager;
+
+	@Unique
+	private static ThreadLocal<Deque<LootManager>> lootContext = new ThreadLocal<Deque<LootManager>>();
+
+	// TODO: is reentrancy necessary?
+	@Inject(method = "apply", at = @At("HEAD"))
+	private void getResourceManager(Map<Identifier, JsonObject> map, ResourceManager resourceManager, Profiler profiler, CallbackInfo info) {
+		this.resourceManager = resourceManager;
+		Deque<LootManager> que = lootContext.get();
+
+		if (que == null) {
+			que = Queues.newArrayDeque();
+			lootContext.set(que);
+		}
+
+		que.push((LootManager) (Object) this);
+	}
+
+	@Inject(method = "apply", at = @At("RETURN"))
+	private void delResourceManager(CallbackInfo info) {
+		// TODO: what if an exception is thrown?
+		resourceManager = null;
+		lootContext.get().pop();
+	}
+
+	@Redirect(method = "method_20711", at = @At(value = "INVOKE", target = "com/google/gson/Gson.fromJson (Lcom/google/gson/JsonElement;Ljava/lang/Class;)Ljava/lang/Object;"))
+	private static Object loadLootTable(Gson GSON, JsonElement elem, Class cls, ImmutableMap.Builder _bld, Identifier id, JsonObject obj) throws IOException {
+		LootManager lootManager = lootContext.get().peek();
+
+		if (lootManager == null) {
+			throw new JsonParseException("Invalid call stack, could not grab loot manager!"); // Should I throw this? Do we care about custom deserializers outside the manager?
+		}
+
+		ResourceManager resourceManager = ((MixinLootManager) (Object) lootManager).resourceManager;
+		Resource res = resourceManager.getResource(((MixinLootManager) (Object) lootManager).getPreparedPath(id));
+		return LootHooks.loadLootTable(GSON, id, elem, res == null || !res.getResourcePackName().equals("Default"), lootManager);
+	}
+}

--- a/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootManager.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootManager.java
@@ -30,13 +30,10 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import jdk.nashorn.internal.codegen.CompilerConstants;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.loot.LootManager;
 import net.minecraft.resource.Resource;

--- a/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootPool.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootPool.java
@@ -1,0 +1,76 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.loot;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+
+import net.minecraft.loot.LootPool;
+import net.minecraft.loot.LootTableRange;
+import net.minecraft.loot.UniformLootTableRange;
+
+import net.patchworkmc.api.loot.ForgeLootPool;
+import net.patchworkmc.impl.loot.PatchworkLootPool;
+
+@Mixin(LootPool.class)
+public class MixinLootPool implements PatchworkLootPool, ForgeLootPool {
+	// Forge has this as final, but I don't have a good way to initialize it if it is final.
+	@Unique
+	private String name;
+
+	@Shadow
+	private UniformLootTableRange bonusRollsRange;
+
+	@Shadow
+	private LootTableRange rollsRange;
+
+	// implementation detail
+	// TODO: if we could have an inner class that was also a mixin, we could set this as protected?
+	public void patchwork$setName(String name) {
+		this.name = name;
+	}
+
+	// Forge methods that should be added directly to the type
+
+	// TODO: freezing stuff
+
+	public String getName() {
+		return this.name;
+	}
+
+	public LootTableRange getRolls() {
+		return rollsRange;
+	}
+
+	public LootTableRange getBonusRolls() {
+		return this.bonusRollsRange;
+	}
+
+	public void setRolls(UniformLootTableRange v) {
+		// checkFrozen();
+		this.rollsRange = v;
+	}
+
+	public void setBonusRolls(UniformLootTableRange v) {
+		// checkFrozen();
+		this.bonusRollsRange = v;
+	}
+}

--- a/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootPool.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootPool.java
@@ -44,6 +44,7 @@ public class MixinLootPool implements PatchworkLootPool, ForgeLootPool {
 
 	// implementation detail
 	// TODO: if we could have an inner class that was also a mixin, we could set this as protected?
+	@Override
 	public void patchwork$setName(String name) {
 		this.name = name;
 	}
@@ -52,23 +53,28 @@ public class MixinLootPool implements PatchworkLootPool, ForgeLootPool {
 
 	// TODO: freezing stuff
 
+	@Override
 	public String getName() {
 		return this.name;
 	}
 
+	@Override
 	public LootTableRange getRolls() {
 		return rollsRange;
 	}
 
+	@Override
 	public LootTableRange getBonusRolls() {
 		return this.bonusRollsRange;
 	}
 
+	@Override
 	public void setRolls(UniformLootTableRange v) {
 		// checkFrozen();
 		this.rollsRange = v;
 	}
 
+	@Override
 	public void setBonusRolls(UniformLootTableRange v) {
 		// checkFrozen();
 		this.bonusRollsRange = v;

--- a/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootPoolBuilder.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootPoolBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.loot;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.loot.LootPool;
+import net.minecraft.loot.UniformLootTableRange;
+
+import net.patchworkmc.api.loot.ForgeLootPool;
+import net.patchworkmc.impl.loot.PatchworkLootPool;
+
+@Mixin(LootPool.Builder.class)
+public abstract class MixinLootPoolBuilder implements ForgeLootPool.Builder {
+	@Unique
+	private String name;
+
+	@Shadow
+	private UniformLootTableRange bonusRollsRange;
+
+	@Inject(method = "build", at = @At("RETURN"), cancellable = true)
+	private void addNameToConstructor(CallbackInfoReturnable<LootPool> cir) {
+		LootPool ret = cir.getReturnValue();
+		((PatchworkLootPool) ret).patchwork$setName(name);
+
+		// is this necessary?
+		cir.setReturnValue(ret);
+	}
+
+	public LootPool.Builder name(String name) {
+		this.name = name;
+		return (LootPool.Builder) (Object) this;
+	}
+
+	public LootPool.Builder bonusRolls(float min, float max) {
+		this.bonusRollsRange = new UniformLootTableRange(min, max);
+		return (LootPool.Builder) (Object) this;
+	}
+}

--- a/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootPoolBuilder.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootPoolBuilder.java
@@ -44,16 +44,15 @@ public abstract class MixinLootPoolBuilder implements ForgeLootPool.Builder {
 	private void addNameToConstructor(CallbackInfoReturnable<LootPool> cir) {
 		LootPool ret = cir.getReturnValue();
 		((PatchworkLootPool) ret).patchwork$setName(name);
-
-		// is this necessary?
-		cir.setReturnValue(ret);
 	}
 
+	@Override
 	public LootPool.Builder name(String name) {
 		this.name = name;
 		return (LootPool.Builder) (Object) this;
 	}
 
+	@Override
 	public LootPool.Builder bonusRolls(float min, float max) {
 		this.bonusRollsRange = new UniformLootTableRange(min, max);
 		return (LootPool.Builder) (Object) this;

--- a/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootPoolSerializer.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootPoolSerializer.java
@@ -1,0 +1,62 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.loot;
+
+import java.lang.reflect.Type;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+
+import net.minecraft.loot.LootPool;
+
+import net.patchworkmc.api.loot.ForgeLootPool;
+import net.patchworkmc.impl.loot.LootHooks;
+import net.patchworkmc.impl.loot.PatchworkLootPool;
+
+@Mixin(LootPool.Serializer.class)
+public class MixinLootPoolSerializer {
+	@Inject(method = "deserialize", at = @At("RETURN"), cancellable = true, locals = LocalCapture.PRINT)
+	private void addNameToConstructor(CallbackInfoReturnable<LootPool> cir, JsonObject obj) {
+		LootPool ret = cir.getReturnValue();
+		((PatchworkLootPool) ret).patchwork$setName(LootHooks.readPoolName(obj));
+
+		// is this necessary?
+		cir.setReturnValue(ret);
+	}
+
+	@Redirect(method = "serialize", at = @At(value = "NEW", args = "class=com/google/gson/JsonObject"))
+	private static JsonObject serializeName(LootPool pool, Type type, JsonSerializationContext ctx) {
+		JsonObject ret = new JsonObject();
+
+		String name = ((ForgeLootPool) pool).getName();
+
+		if (name != null && !name.startsWith("custom#")) {
+			ret.add("name", ctx.serialize(name));
+		}
+
+		return ret;
+	}
+}

--- a/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootPoolSerializer.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootPoolSerializer.java
@@ -21,6 +21,8 @@ package net.patchworkmc.mixin.loot;
 
 import java.lang.reflect.Type;
 
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -38,8 +40,8 @@ import net.patchworkmc.impl.loot.PatchworkLootPool;
 
 @Mixin(LootPool.Serializer.class)
 public class MixinLootPoolSerializer {
-	@Inject(method = "deserialize", at = @At("RETURN"), cancellable = true, locals = LocalCapture.PRINT)
-	private void addNameToConstructor(CallbackInfoReturnable<LootPool> cir, JsonObject obj) {
+	@Inject(method = "deserialize", at = @At("RETURN"), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
+	private void addNameToConstructor(JsonElement elem, Type ty, JsonDeserializationContext ctx, CallbackInfoReturnable<LootPool> cir, JsonObject obj) {
 		LootPool ret = cir.getReturnValue();
 		((PatchworkLootPool) ret).patchwork$setName(LootHooks.readPoolName(obj));
 

--- a/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootTable.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootTable.java
@@ -41,10 +41,12 @@ public class MixinLootTable implements ForgeLootTable {
 
 	// TODO: freezing stuff
 
+	@Override
 	public LootPool getPool(String name) {
 		return ((FabricLootSupplier) this).getPools().stream().filter(e -> name.equals(((ForgeLootPool) e).getName())).findFirst().orElse(null);
 	}
 
+	@Override
 	public LootPool removePool(String name) {
 		// checkFrozen();
 		for (int idx = 0; idx < pools.length; ++idx) {
@@ -60,6 +62,7 @@ public class MixinLootTable implements ForgeLootTable {
 		return null;
 	}
 
+	@Override
 	public void addPool(LootPool pool) {
 		// checkFrozen();
 		if (((FabricLootSupplier) this).getPools().stream().anyMatch(e -> e == pool || ((ForgeLootPool) e).getName().equals(((ForgeLootPool) pool).getName()))) {

--- a/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootTable.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/mixin/loot/MixinLootTable.java
@@ -1,0 +1,72 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.loot;
+
+import java.util.Arrays;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.loot.LootPool;
+import net.minecraft.loot.LootTable;
+
+import net.fabricmc.fabric.api.loot.v1.FabricLootSupplier;
+
+import net.patchworkmc.api.loot.ForgeLootTable;
+import net.patchworkmc.api.loot.ForgeLootPool;
+
+@Mixin(LootTable.class)
+public class MixinLootTable implements ForgeLootTable {
+	@Shadow
+	LootPool[] pools;
+
+	// Forge added methods
+
+	// TODO: freezing stuff
+
+	public LootPool getPool(String name) {
+		return ((FabricLootSupplier) this).getPools().stream().filter(e -> name.equals(((ForgeLootPool) e).getName())).findFirst().orElse(null);
+	}
+
+	public LootPool removePool(String name) {
+		// checkFrozen();
+		for (int idx = 0; idx < pools.length; ++idx) {
+			LootPool pool = pools[idx];
+
+			if (name.equals(((ForgeLootPool) pool).getName())) {
+				// https://stackoverflow.com/a/644764
+				System.arraycopy(pools, idx + 1, pools, idx, pools.length - 1 - idx);
+				return pool;
+			}
+		}
+
+		return null;
+	}
+
+	public void addPool(LootPool pool) {
+		// checkFrozen();
+		if (((FabricLootSupplier) this).getPools().stream().anyMatch(e -> e == pool || ((ForgeLootPool) e).getName().equals(((ForgeLootPool) pool).getName()))) {
+			throw new RuntimeException("Attempted to add a duplicate pool to loot table: " + ((ForgeLootPool) pool).getName());
+		}
+
+		pools = Arrays.copyOf(pools, pools.length + 1);
+		pools[pools.length - 1] = pool;
+	}
+}

--- a/patchwork-loot/src/main/resources/patchwork-loot.mixins.json
+++ b/patchwork-loot/src/main/resources/patchwork-loot.mixins.json
@@ -5,7 +5,13 @@
   "mixins": [
     "MixinAdvancementRewards",
     "MixinFishingBobberEntity",
-    "MixinLootContextTypes"
+    "MixinJsonDataLoader",
+    "MixinLootContextTypes",
+    "MixinLootManager",
+    "MixinLootPool",
+    "MixinLootPoolBuilder",
+    "MixinLootPoolSerializer",
+    "MixinLootTable"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
The mixin to LootManager is messy, and I'm open to alternative ways to doing it, even if it involves doing it in a completely different way from how forge does it. For now, I'm going to get this up so that bikeshedding can happen.

I'm using the "net.patchworkmc.api.*.Forge<classname>" pattern for interfaces that describe public methods added by Forge for use by mods in this commit. This is up for bikeshedding.

This is untested other than starting up Minecraft and opening a world. I was originally going to at least use the mod mentioned in #110, but it doesn't appear to have a version for 1.14.4, and I didn't feel like trying to run a 1.15.2 mod through patcher and hoping it worked.

The reason why this PR doesn't simply add/dispatch the LootTableLoadEvent is because many consumers of the event (according to github search) call methods on LootPool and/or LootTable.