### PR TITLE
Dispatch from ForgeHooks to WorldEvents

### DIFF
--- a/patchwork-events-world/src/main/java/net/patchworkmc/impl/event/world/WorldEvents.java
+++ b/patchwork-events-world/src/main/java/net/patchworkmc/impl/event/world/WorldEvents.java
@@ -23,10 +23,16 @@ import java.util.Collections;
 import java.util.List;
 
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.DifficultyChangeEvent;
+import net.minecraftforge.event.world.ChunkWatchEvent;
 import net.minecraftforge.event.world.WorldEvent;
 
 import net.minecraft.entity.EntityCategory;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.Difficulty;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.level.LevelInfo;
@@ -56,5 +62,18 @@ public class WorldEvents {
 
 	public static void onWorldSave(IWorld world) {
 		MinecraftForge.EVENT_BUS.post(new WorldEvent.Save(world));
+	}
+
+	// TODO: Is this actually a "world" event?
+	public static void onDifficultyChange(Difficulty difficulty, Difficulty oldDifficulty) {
+		MinecraftForge.EVENT_BUS.post(new DifficultyChangeEvent(difficulty, oldDifficulty));
+	}
+
+	public static void fireChunkWatch(boolean watch, ServerPlayerEntity entity, ChunkPos chunkpos, ServerWorld world) {
+		if (watch) {
+			MinecraftForge.EVENT_BUS.post(new ChunkWatchEvent.Watch(entity, chunkpos, world));
+		} else {
+			throw new UnsupportedOperationException("Cannot Unwatch a chunk yet");
+		}
 	}
 }

--- a/patchwork-events-world/src/main/java/net/patchworkmc/mixin/event/world/MixinThreadedAnvilChunkStorage.java
+++ b/patchwork-events-world/src/main/java/net/patchworkmc/mixin/event/world/MixinThreadedAnvilChunkStorage.java
@@ -33,6 +33,8 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.server.world.ThreadedAnvilChunkStorage;
 import net.minecraft.util.math.ChunkPos;
 
+import net.patchworkmc.impl.event.world.WorldEvents;
+
 @Mixin(ThreadedAnvilChunkStorage.class)
 public class MixinThreadedAnvilChunkStorage {
 	@Shadow
@@ -41,9 +43,7 @@ public class MixinThreadedAnvilChunkStorage {
 	@Inject(method = "sendWatchPackets", at = @At("HEAD"))
 	private void fireWatchEvents(ServerPlayerEntity player, ChunkPos pos, Packet<?>[] packets, boolean withinMaxWatchDistance, boolean withinViewDistance, CallbackInfo callback) {
 		if (withinViewDistance && !withinMaxWatchDistance) {
-			ChunkWatchEvent.Watch event = new ChunkWatchEvent.Watch(player, pos, world);
-
-			MinecraftForge.EVENT_BUS.post(event);
+			WorldEvents.fireChunkWatch(true, player, pos, world);
 		}
 	}
 }

--- a/patchwork-events-world/src/main/java/net/patchworkmc/mixin/event/world/MixinThreadedAnvilChunkStorage.java
+++ b/patchwork-events-world/src/main/java/net/patchworkmc/mixin/event/world/MixinThreadedAnvilChunkStorage.java
@@ -19,8 +19,6 @@
 
 package net.patchworkmc.mixin.event.world;
 
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.world.ChunkWatchEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;

--- a/patchwork-god-classes/build.gradle
+++ b/patchwork-god-classes/build.gradle
@@ -4,4 +4,5 @@ version = getSubprojectVersion(project, "0.1.0")
 dependencies {
 	compile project(path: ':patchwork-fml', configuration: 'dev')
 	compile project(path: ':patchwork-events-lifecycle', configuration: 'dev')
+	compile project(path: ':patchwork-events-world', configuration: 'dev')
 }

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -19,9 +19,42 @@
 
 package net.minecraftforge.common;
 
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.entity.EntityCategory;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.Difficulty;
+import net.minecraft.world.IWorld;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.level.LevelInfo;
+
+import net.patchworkmc.impl.event.world.WorldEvents;
+
 /*
  * Note: this class is intended for mod use only, to dispatch to the implementations kept in their own modules.
  * Do not keep implementation details here, methods should be thin wrappers around methods in other modules.
  */
 public class ForgeHooks {
+	public static boolean onCreateWorldSpawn(World world, LevelInfo settings) {
+		return WorldEvents.onCreateWorldSpawn(world, settings);
+	}
+
+	@Nullable
+	public static List<Biome.SpawnEntry> getPotentialSpawns(IWorld world, EntityCategory type, BlockPos pos, List<Biome.SpawnEntry> oldList) {
+		return WorldEvents.getPotentialSpawns(world, type, pos, oldList);
+	}
+
+	public static void onDifficultyChange(Difficulty difficulty, Difficulty oldDifficulty) {
+		WorldEvents.onDifficultyChange(difficulty, oldDifficulty);
+	}
+
+	public static void fireChunkWatch(boolean watch, ServerPlayerEntity entity, ChunkPos chunkpos, ServerWorld world) {
+		WorldEvents.fireChunkWatch(watch, entity, chunkpos, world);
+	}
 }

--- a/patchwork-god-classes/src/main/resources/fabric.mod.json
+++ b/patchwork-god-classes/src/main/resources/fabric.mod.json
@@ -17,7 +17,8 @@
   "depends": {
     "fabricloader": ">=0.8.4",
     "patchwork-fml": "*",
-    "patchwork-events-lifecycle": "*"
+    "patchwork-events-lifecycle": "*",
+    "patchwork-events-world": "*"
   },
   "custom": {
     "modmenu:api": true,


### PR DESCRIPTION
Originally in #121, I broke out onBlockBreakEvent to WorldEvents as well. However, this is also being performed in #126, so for the moment I'm going to leave that to #126 unless otherwise requested.

I'm also not really certain where `onDifficultyChange` should go. I placed it in the world module in #121, but now i'm not so sure.