### PR TITLE
Add access widener for SpawnRestriction.register

### DIFF
--- a/patchwork-registries/build.gradle
+++ b/patchwork-registries/build.gradle
@@ -4,3 +4,7 @@ version = getSubprojectVersion(project, "0.3.0")
 dependencies {
 	compile project(path: ':patchwork-fml', configuration: 'dev')
 }
+
+minecraft {
+	accessWidener "src/main/resources/patchwork-registries.accesswidener"
+}

--- a/patchwork-registries/src/main/resources/fabric.mod.json
+++ b/patchwork-registries/src/main/resources/fabric.mod.json
@@ -20,6 +20,7 @@
   "mixins": [
     "patchwork-registries.mixins.json"
   ],
+  "accessWidener": "patchwork-registries.accesswidener",
   "custom": {
     "modmenu:api": true,
     "modmenu:parent": "patchwork"

--- a/patchwork-registries/src/main/resources/patchwork-registries.accesswidener
+++ b/patchwork-registries/src/main/resources/patchwork-registries.accesswidener
@@ -1,0 +1,3 @@
+accessWidener v1 named
+
+accessible method net/minecraft/entity/SpawnRestriction register (Lnet/minecraft/entity/EntityType;Lnet/minecraft/entity/SpawnRestriction$Location;Lnet/minecraft/world/Heightmap$Type;Lnet/minecraft/entity/SpawnRestriction$class_4306;)V


### PR DESCRIPTION
Simple change that adds a single access widener. This method is AT'd by Forge and commonly used by mods that add mobs.
Fixes #31 