### PR TITLE
Better loottable hooks

### DIFF
--- a/patchwork-loot/src/main/java/net/patchworkmc/impl/loot/LootHooks.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/impl/loot/LootHooks.java
@@ -19,18 +19,12 @@
 
 package net.patchworkmc.impl.loot;
 
-import java.util.Deque;
-import java.util.HashSet;
-
-import javax.annotation.Nullable;
-
-import com.google.common.collect.Queues;
-import com.google.common.collect.Sets;
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import org.spongepowered.asm.mixin.Unique;
+import org.apache.commons.lang3.mutable.MutableInt;
 
 import net.minecraft.loot.LootManager;
 import net.minecraft.loot.LootTable;
@@ -39,29 +33,60 @@ import net.minecraft.util.JsonHelper;
 
 import net.patchworkmc.impl.event.loot.LootEvents;
 
-// NOTE: this class is more or less a direct copy of parts of Forge's ForgeHooks.
 public class LootHooks {
-	@Unique
-	private static ThreadLocal<Deque<LootTableContext>> lootContext = new ThreadLocal<Deque<LootTableContext>>();
+	public static void prepareLootTable(Identifier id, JsonObject lootTableObj, boolean custom, LootManager lootTableManager) {
+		// passing 'custom' value into lambda mixin via json after json parsing
+		lootTableObj.addProperty("custom", custom);
 
+		// passing pool names into loot pool deserialization mixin since we have all the information we need now
+		if (lootTableObj.has("pools")) {
+			MutableInt poolCount = new MutableInt(0);
+			JsonArray pools = lootTableObj.getAsJsonArray("pools");
+
+			for (JsonElement elem: pools) {
+				JsonObject pool = JsonHelper.asObject(elem, "loot pool");
+				String name = getPoolName(pool, id, custom, poolCount);
+				pool.addProperty("name", name);
+			}
+		}
+
+		// we don't call GSON here because we're letting vanilla do it in a bit.
+		// ForgeHooks implementation wraps this, performing the deserialization
+	}
+
+	// More or less a copy of ForgeHooks.readPoolName. Actual implementation of that will just pull the name
+	// from the json, since prepareLootTable is taking the name from this and putting it in the json.
+	private static String getPoolName(JsonObject lootPoolObj, Identifier id, boolean custom, MutableInt poolCount) {
+		boolean vanilla = "minecraft".equals(id.getNamespace());
+
+		if (lootPoolObj.has("name")) {
+			return JsonHelper.getString(lootPoolObj, "name");
+		}
+
+		if (custom) {
+			return "custom#" + lootPoolObj.hashCode(); //We don't care about custom ones modders shouldn't be editing them!
+		}
+
+		poolCount.increment();
+
+		if (!vanilla) {
+			throw new JsonParseException("Loot Table \"" + ctx.name.toString() + "\" Missing `name` entry for pool #" + (ctx.poolCount - 1));
+		}
+
+		return poolCount.intValue() == 1 ? "main" : "pool" + (poolCount.intValue() - 1);
+	}
+
+	// TODO: should we move this implementation to ForgeHooks? since this is only going to be called by ForgeHooks.
 	public static LootTable loadLootTable(Gson gson, Identifier name, JsonElement data, boolean custom, LootManager lootTableManager) {
-		Deque<LootTableContext> que = lootContext.get();
+		JsonObject lootTableObj = JsonHelper.asObject(data, "loot table");
 
-		if (que == null) {
-			que = Queues.newArrayDeque();
-			lootContext.set(que);
-		}
+		// This accomplishes the stashing of data that Forge does, without needing a threadlocal static
+		prepareLootTable(name, lootTableObj, custom, lootTableManager);
 
-		LootTable ret = null;
+		// TODO: Can we do something like call the lambda method directly?
+		//       As is, we're gonna duplicate the stuff we add via mixin.
 
-		try {
-			que.push(new LootTableContext(name, custom));
-			ret = gson.fromJson(data, LootTable.class);
-			que.pop();
-		} catch (JsonParseException e) {
-			que.pop();
-			throw e;
-		}
+		LootTable ret = gson.fromJson(data, LootTable.class);
 
 		if (!custom) {
 			ret = LootEvents.loadLootTable(name, ret, lootTableManager);
@@ -74,76 +99,9 @@ public class LootHooks {
 		return ret;
 	}
 
-	private static LootTableContext getLootTableContext() {
-		LootTableContext ctx = lootContext.get().peek();
-
-		if (ctx == null) {
-			throw new JsonParseException("Invalid call stack, could not grab json context!"); // Should I throw this? Do we care about custom deserializers outside the manager?
-		}
-
-		return ctx;
-	}
-
-	public static String readPoolName(JsonObject json) {
-		LootTableContext ctx = LootHooks.getLootTableContext();
-		ctx.resetPoolCtx();
-
-		if (json.has("name")) {
-			return JsonHelper.getString(json, "name");
-		}
-
-		if (ctx.custom) {
-			return "custom#" + json.hashCode(); //We don't care about custom ones modders shouldn't be editing them!
-		}
-
-		ctx.poolCount++;
-
-		if (!ctx.vanilla) {
-			throw new JsonParseException("Loot Table \"" + ctx.name.toString() + "\" Missing `name` entry for pool #" + (ctx.poolCount - 1));
-		}
-
-		return ctx.poolCount == 1 ? "main" : "pool" + (ctx.poolCount - 1);
-	}
-
-	private static class LootTableContext {
-		public final Identifier name;
-		public final boolean custom;
-		private final boolean vanilla;
-		public int poolCount = 0;
-		public int entryCount = 0;
-		private HashSet<String> entryNames = Sets.newHashSet();
-
-		private LootTableContext(Identifier name, boolean custom) {
-			this.name = name;
-			this.custom = custom;
-			this.vanilla = "minecraft".equals(this.name.getNamespace());
-		}
-
-		private void resetPoolCtx() {
-			this.entryCount = 0;
-			this.entryNames.clear();
-		}
-
-		public String validateEntryName(@Nullable String name) {
-			if (name != null && !this.entryNames.contains(name)) {
-				this.entryNames.add(name);
-				return name;
-			}
-
-			if (!this.vanilla) {
-				throw new JsonParseException("Loot Table \"" + this.name.toString() + "\" Duplicate entry name \"" + name + "\" for pool #" + (this.poolCount - 1) + " entry #" + (this.entryCount - 1));
-			}
-
-			int x = 0;
-
-			while (this.entryNames.contains(name + "#" + x)) {
-				x++;
-			}
-
-			name = name + "#" + x;
-			this.entryNames.add(name);
-
-			return name;
-		}
+	// Replacement for ForgeHooks.readPoolName: since we prepared the json object, the name is already present.
+	public static String readPoolName(JsonObject lootPoolObj) {
+		// TODO: throw a better exception?
+		return JsonHelper.getString(lootPoolObj, "name");
 	}
 }

--- a/patchwork-loot/src/main/java/net/patchworkmc/impl/loot/LootHooks.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/impl/loot/LootHooks.java
@@ -35,10 +35,7 @@ import net.patchworkmc.impl.event.loot.LootEvents;
 
 public class LootHooks {
 	public static void prepareLootTable(Identifier id, JsonObject lootTableObj, boolean custom, LootManager lootTableManager) {
-		// passing 'custom' value into lambda mixin via json after json parsing
-		lootTableObj.addProperty("custom", custom);
-
-		// passing pool names into loot pool deserialization mixin since we have all the information we need now
+		// passing pool names into loot pool deserialization mixin since we have all the information we need right now, but not later
 		if (lootTableObj.has("pools")) {
 			MutableInt poolCount = new MutableInt(0);
 			JsonArray pools = lootTableObj.getAsJsonArray("pools");

--- a/patchwork-loot/src/main/java/net/patchworkmc/impl/loot/WrappedImmutableMapBuilder.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/impl/loot/WrappedImmutableMapBuilder.java
@@ -1,0 +1,30 @@
+package net.patchworkmc.impl.loot;
+
+import java.util.function.BiFunction;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import com.google.common.collect.ImmutableMap;
+
+import net.patchworkmc.mixin.loot.MixinLootManager;
+
+/**
+ * A builder for creating immutable map instances that applies some sort of transformation
+ * before putting items into the map. See {@link ImmutableMap.Builder} for normal usage.
+ *
+ * <p>Yes, this is a hack, see usage in {@link MixinLootManager}</p>
+ */
+@ParametersAreNonnullByDefault
+public class WrappedImmutableMapBuilder<K, V> extends ImmutableMap.Builder<K, V> {
+	private final BiFunction<K, V, V> wrap;
+
+	public WrappedImmutableMapBuilder(BiFunction<K, V, V> wrap) {
+		super();
+		this.wrap = wrap;
+	}
+
+	@Override
+	public ImmutableMap.Builder<K, V> put(K key, V value) {
+		return super.put(key, wrap.apply(key, value));
+	}
+}


### PR DESCRIPTION
Opening this as a draft pull request so we can discuss.

I believe there's still an error present, but it's just a matter of how we handle an exception.

The whole idea is to cut out the static `ThreadLocal<Deque<...>>` in LootHooks in favor of messing with json. However, this PR also includes a technique we could use to avoid overwriting the lambda that could be pulled in on its own. (see second commit)