### PR TITLE
Correct ExtendedForgeRegistryEntry's bytecode interface and correct the generics on ForgeRegistryEntry

### DIFF
--- a/patchwork-registries/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
+++ b/patchwork-registries/src/main/java/net/minecraftforge/registries/ForgeRegistryEntry.java
@@ -21,7 +21,7 @@ package net.minecraftforge.registries;
 
 import net.minecraft.util.Identifier;
 
-public abstract class ForgeRegistryEntry<V> implements IForgeRegistryEntry<V> {
+public abstract class ForgeRegistryEntry<V extends IForgeRegistryEntry<V>> implements IForgeRegistryEntry<V> {
 	private Identifier registryName;
 
 	@Override

--- a/patchwork-registries/src/main/java/net/patchworkmc/impl/registries/ExtendedForgeRegistryEntry.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/impl/registries/ExtendedForgeRegistryEntry.java
@@ -24,8 +24,9 @@ import net.minecraftforge.registries.IForgeRegistryEntry;
 
 import net.minecraft.util.Identifier;
 
+@SuppressWarnings("unchecked")
 public interface ExtendedForgeRegistryEntry<V> extends IForgeRegistryEntry<V> {
-	default V setRegistryName(String full) {
+	default IForgeRegistryEntry<V> setRegistryName(String full) {
 		String activeNamespace = ModLoadingContext.get().getActiveNamespace();
 
 		if (activeNamespace == null || activeNamespace.equals("minecraft")) {
@@ -44,10 +45,10 @@ public interface ExtendedForgeRegistryEntry<V> extends IForgeRegistryEntry<V> {
 			System.err.printf("Potentially Dangerous alternative prefix `%s` for name `%s`, expected `%s`. This could be a intended override, but in most cases indicates a broken mod.\n", identifier.getNamespace(), identifier.getPath(), activeNamespace);
 		}
 
-		return this.setRegistryName(identifier);
+		return (IForgeRegistryEntry<V>) this.setRegistryName(identifier);
 	}
 
-	default V setRegistryName(String namespace, String name) {
-		return this.setRegistryName(new Identifier(namespace, name));
+	default IForgeRegistryEntry<V> setRegistryName(String namespace, String name) {
+		return (IForgeRegistryEntry<V>) this.setRegistryName(new Identifier(namespace, name));
 	}
 }


### PR DESCRIPTION
Should've been part of #131, but didn't notice in time. It turns out that ForgeRegistryEntry has the generic `<V extends IForgeRegistryEntry<V>>`, not just `<V>` and we need to mimic the bytecode that would produce.