### PR TITLE
Implement ChunkWatchEvent.UnWatch

### DIFF
--- a/patchwork-events-world/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
+++ b/patchwork-events-world/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
@@ -91,9 +91,9 @@ public class ChunkWatchEvent extends Event {
 	 *
 	 * <p>This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.</p>
 	 */
-	/* TODO public static class UnWatch extends ChunkWatchEvent {
+	public static class UnWatch extends ChunkWatchEvent {
 		public UnWatch(ServerPlayerEntity player, ChunkPos pos, ServerWorld world) {
 			super(player, pos, world);
 		}
-	}*/
+	}
 }

--- a/patchwork-events-world/src/main/java/net/patchworkmc/impl/event/world/WorldEvents.java
+++ b/patchwork-events-world/src/main/java/net/patchworkmc/impl/event/world/WorldEvents.java
@@ -72,6 +72,7 @@ public class WorldEvents implements ModInitializer {
 		} else {
 			MinecraftForge.EVENT_BUS.post(new ChunkWatchEvent.UnWatch(entity, chunkpos, world));
 		}
+	}
 
 	@Override
 	public void onInitialize() {

--- a/patchwork-events-world/src/main/java/net/patchworkmc/impl/event/world/WorldEvents.java
+++ b/patchwork-events-world/src/main/java/net/patchworkmc/impl/event/world/WorldEvents.java
@@ -23,10 +23,14 @@ import java.util.Collections;
 import java.util.List;
 
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.ChunkWatchEvent;
 import net.minecraftforge.event.world.WorldEvent;
 
 import net.minecraft.entity.EntityCategory;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.level.LevelInfo;
@@ -56,5 +60,13 @@ public class WorldEvents {
 
 	public static void onWorldSave(IWorld world) {
 		MinecraftForge.EVENT_BUS.post(new WorldEvent.Save(world));
+	}
+
+	public static void fireChunkWatch(boolean watch, ServerPlayerEntity entity, ChunkPos chunkpos, ServerWorld world) {
+		if (watch) {
+			MinecraftForge.EVENT_BUS.post(new ChunkWatchEvent.Watch(entity, chunkpos, world));
+		} else {
+			MinecraftForge.EVENT_BUS.post(new ChunkWatchEvent.UnWatch(entity, chunkpos, world));
+		}
 	}
 }

--- a/patchwork-events-world/src/main/java/net/patchworkmc/mixin/event/world/MixinThreadedAnvilChunkStorage.java
+++ b/patchwork-events-world/src/main/java/net/patchworkmc/mixin/event/world/MixinThreadedAnvilChunkStorage.java
@@ -19,8 +19,6 @@
 
 package net.patchworkmc.mixin.event.world;
 
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.world.ChunkWatchEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -33,6 +31,8 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.server.world.ThreadedAnvilChunkStorage;
 import net.minecraft.util.math.ChunkPos;
 
+import net.patchworkmc.impl.event.world.WorldEvents;
+
 @Mixin(ThreadedAnvilChunkStorage.class)
 public class MixinThreadedAnvilChunkStorage {
 	@Shadow
@@ -40,10 +40,8 @@ public class MixinThreadedAnvilChunkStorage {
 
 	@Inject(method = "sendWatchPackets", at = @At("HEAD"))
 	private void fireWatchEvents(ServerPlayerEntity player, ChunkPos pos, Packet<?>[] packets, boolean withinMaxWatchDistance, boolean withinViewDistance, CallbackInfo callback) {
-		if (withinViewDistance && !withinMaxWatchDistance) {
-			ChunkWatchEvent.Watch event = new ChunkWatchEvent.Watch(player, pos, world);
-
-			MinecraftForge.EVENT_BUS.post(event);
+		if (this.world == player.world && withinMaxWatchDistance != withinViewDistance) {
+			WorldEvents.fireChunkWatch(withinViewDistance, player, pos, this.world);
 		}
 	}
 }


### PR DESCRIPTION
NOTE: This implementation follows upstream 1.14.4 Forge, not the commit we're tracking which doesn't implement it at all. Or maybe it does and I'm misremembering since I did this last night.

I don't actually know of any mods that uses this event, but it's been bugging me that it's half implemented, especially since forge uses the same patch to implement both events.