### PR TITLE
Use Fabric's world load event.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ allprojects {
 		minecraft "com.mojang:minecraft:$Globals.mcVersion"
 		mappings "net.fabricmc:yarn:${Globals.mcVersion}${Globals.yarnVersion}:v2"
 		modCompile "net.fabricmc:fabric-loader:0.8.4+build.198"
-		modCompile "net.fabricmc.fabric-api:fabric-api:0.4.2+build.246-1.14"
+		modCompile "net.fabricmc.fabric-api:fabric-api:0.15.1+build.260-1.14"
 
 		implementation 'net.patchworkmc:patchwork-eventbus:2.0.1:all'
 		implementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/patchwork-events-world/src/main/java/net/patchworkmc/impl/event/world/WorldEvents.java
+++ b/patchwork-events-world/src/main/java/net/patchworkmc/impl/event/world/WorldEvents.java
@@ -29,6 +29,7 @@ import net.minecraft.entity.EntityCategory;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.dimension.DimensionType;
 import net.minecraft.world.level.LevelInfo;
 
 import net.fabricmc.api.ModInitializer;
@@ -64,7 +65,11 @@ public class WorldEvents implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		ServerWorldEvents.LOAD.register((server, world) -> {
-			onWorldLoad(world);
+			// Fabric fires this much earlier than Forge does for the overworld
+			// So, we're going to manually fire it for the overworld.
+			if (world.getDimension().getType() != DimensionType.OVERWORLD) {
+				onWorldLoad(world);
+			}
 		});
 	}
 }

--- a/patchwork-events-world/src/main/java/net/patchworkmc/impl/event/world/WorldEvents.java
+++ b/patchwork-events-world/src/main/java/net/patchworkmc/impl/event/world/WorldEvents.java
@@ -31,7 +31,10 @@ import net.minecraft.world.IWorld;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.level.LevelInfo;
 
-public class WorldEvents {
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
+
+public class WorldEvents implements ModInitializer {
 	public static boolean onCreateWorldSpawn(IWorld world, LevelInfo settings) {
 		return MinecraftForge.EVENT_BUS.post(new WorldEvent.CreateSpawnPosition(world, settings));
 	}
@@ -56,5 +59,12 @@ public class WorldEvents {
 
 	public static void onWorldSave(IWorld world) {
 		MinecraftForge.EVENT_BUS.post(new WorldEvent.Save(world));
+	}
+
+	@Override
+	public void onInitialize() {
+		ServerWorldEvents.LOAD.register((server, world) -> {
+			onWorldLoad(world);
+		});
 	}
 }

--- a/patchwork-events-world/src/main/resources/fabric.mod.json
+++ b/patchwork-events-world/src/main/resources/fabric.mod.json
@@ -14,6 +14,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.8.4",
+    "fabric": ">=0.15.0",
     "patchwork-fml": "*"
   },
   "mixins": [


### PR DESCRIPTION
Fixes #148.

Minor point of discussion: how much do we care about the overworld event being fired earlier than Forge does it? I've separated out the workaround for that into the second commit, so that can easily be removed if we want.