### PR TITLE
Use raw types to "hand erase" ExtendedForgeRegistryEntry's generics

### DIFF
--- a/patchwork-registries/src/main/java/net/patchworkmc/impl/registries/ExtendedForgeRegistryEntry.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/impl/registries/ExtendedForgeRegistryEntry.java
@@ -25,8 +25,8 @@ import net.minecraftforge.registries.IForgeRegistryEntry;
 import net.minecraft.util.Identifier;
 
 @SuppressWarnings("unchecked")
-public interface ExtendedForgeRegistryEntry<V> extends IForgeRegistryEntry<V> {
-	default IForgeRegistryEntry<V> setRegistryName(String full) {
+public interface ExtendedForgeRegistryEntry<V extends IForgeRegistryEntry<V>> extends IForgeRegistryEntry<V> {
+	default V setRegistryName(String full) {
 		String activeNamespace = ModLoadingContext.get().getActiveNamespace();
 
 		if (activeNamespace == null || activeNamespace.equals("minecraft")) {
@@ -45,10 +45,13 @@ public interface ExtendedForgeRegistryEntry<V> extends IForgeRegistryEntry<V> {
 			System.err.printf("Potentially Dangerous alternative prefix `%s` for name `%s`, expected `%s`. This could be a intended override, but in most cases indicates a broken mod.\n", identifier.getNamespace(), identifier.getPath(), activeNamespace);
 		}
 
-		return (IForgeRegistryEntry<V>) this.setRegistryName(identifier);
+		return this.setRegistryName(identifier);
 	}
 
-	default IForgeRegistryEntry<V> setRegistryName(String namespace, String name) {
-		return (IForgeRegistryEntry<V>) this.setRegistryName(new Identifier(namespace, name));
+	default V setRegistryName(String namespace, String name) {
+		return this.setRegistryName(new Identifier(namespace, name));
 	}
+
+	@Override
+	V setRegistryName(Identifier name);
 }

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinActivity.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinActivity.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(Activity.class)
-public class MixinActivity implements ExtendedForgeRegistryEntry<Activity> {
+public class MixinActivity implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public Activity setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (Activity) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinBiome.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinBiome.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(Biome.class)
-public class MixinBiome implements ExtendedForgeRegistryEntry<Biome> {
+public class MixinBiome implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public Biome setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (Biome) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinBiomeSourceType.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinBiomeSourceType.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(BiomeSourceType.class)
-public class MixinBiomeSourceType implements ExtendedForgeRegistryEntry<BiomeSourceType> {
+public class MixinBiomeSourceType implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public BiomeSourceType setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (BiomeSourceType) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinBlock.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinBlock.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(Block.class)
-public class MixinBlock implements ExtendedForgeRegistryEntry<Block> {
+public class MixinBlock implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public Block setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (Block) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinBlockEntityType.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinBlockEntityType.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(BlockEntityType.class)
-public class MixinBlockEntityType implements ExtendedForgeRegistryEntry<BlockEntityType> {
+public class MixinBlockEntityType implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public BlockEntityType setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (BlockEntityType) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinCarver.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinCarver.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(Carver.class)
-public class MixinCarver implements ExtendedForgeRegistryEntry<Carver> {
+public class MixinCarver implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public Carver setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (Carver) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinChunkGeneratorType.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinChunkGeneratorType.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(ChunkGeneratorType.class)
-public class MixinChunkGeneratorType implements ExtendedForgeRegistryEntry<ChunkGeneratorType> {
+public class MixinChunkGeneratorType implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public ChunkGeneratorType setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (ChunkGeneratorType) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinChunkStatus.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinChunkStatus.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(ChunkStatus.class)
-public class MixinChunkStatus implements ExtendedForgeRegistryEntry<ChunkStatus> {
+public class MixinChunkStatus implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public ChunkStatus setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (ChunkStatus) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinContainerType.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinContainerType.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(ContainerType.class)
-public class MixinContainerType implements ExtendedForgeRegistryEntry<ContainerType> {
+public class MixinContainerType implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public ContainerType setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (ContainerType) (Object) this;
+		return (IForgeRegistryEntry) this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinDecorator.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinDecorator.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(Decorator.class)
-public class MixinDecorator implements ExtendedForgeRegistryEntry<Decorator> {
+public class MixinDecorator implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public Decorator setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (Decorator) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinEnchantment.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinEnchantment.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(Enchantment.class)
-public class MixinEnchantment implements ExtendedForgeRegistryEntry<Enchantment> {
+public class MixinEnchantment implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public Enchantment setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (Enchantment) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinEntityType.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinEntityType.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(EntityType.class)
-public class MixinEntityType implements ExtendedForgeRegistryEntry<EntityType> {
+public class MixinEntityType implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public EntityType setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (EntityType) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinFeature.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinFeature.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(Feature.class)
-public class MixinFeature implements ExtendedForgeRegistryEntry<Feature> {
+public class MixinFeature implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public Feature setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (Feature) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinFluid.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinFluid.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(Fluid.class)
-public class MixinFluid implements ExtendedForgeRegistryEntry<Fluid> {
+public class MixinFluid implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public Fluid setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (Fluid) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinItem.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinItem.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(Item.class)
-public class MixinItem implements ExtendedForgeRegistryEntry<Item> {
+public class MixinItem implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public Item setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (Item) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinMemoryModuleType.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinMemoryModuleType.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(MemoryModuleType.class)
-public class MixinMemoryModuleType implements ExtendedForgeRegistryEntry<MemoryModuleType> {
+public class MixinMemoryModuleType implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public MemoryModuleType setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (MemoryModuleType) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinPaintingMotive.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinPaintingMotive.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(PaintingMotive.class)
-public class MixinPaintingMotive implements ExtendedForgeRegistryEntry<PaintingMotive> {
+public class MixinPaintingMotive implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public PaintingMotive setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (PaintingMotive) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinParticleType.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinParticleType.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(ParticleType.class)
-public class MixinParticleType implements ExtendedForgeRegistryEntry<ParticleType> {
+public class MixinParticleType implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public ParticleType setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (ParticleType) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinPointOfInterestType.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinPointOfInterestType.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(PointOfInterestType.class)
-public class MixinPointOfInterestType implements ExtendedForgeRegistryEntry<PointOfInterestType> {
+public class MixinPointOfInterestType implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public PointOfInterestType setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (PointOfInterestType) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinPotion.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinPotion.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(Potion.class)
-public class MixinPotion implements ExtendedForgeRegistryEntry<Potion> {
+public class MixinPotion implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public Potion setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (Potion) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinRecipeSerializerSubclass.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinRecipeSerializerSubclass.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -35,15 +36,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin({ShapedRecipe.Serializer.class, ShapelessRecipe.Serializer.class, CookingRecipeSerializer.class, CuttingRecipe.Serializer.class, SpecialRecipeSerializer.class})
-public class MixinRecipeSerializerSubclass implements ExtendedForgeRegistryEntry<RecipeSerializer> {
+public class MixinRecipeSerializerSubclass implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public RecipeSerializer setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (RecipeSerializer) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinSchedule.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinSchedule.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(Schedule.class)
-public class MixinSchedule implements ExtendedForgeRegistryEntry<Schedule> {
+public class MixinSchedule implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public Schedule setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (Schedule) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinSensorType.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinSensorType.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(SensorType.class)
-public class MixinSensorType implements ExtendedForgeRegistryEntry<SensorType> {
+public class MixinSensorType implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public SensorType setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (SensorType) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinSoundEvent.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinSoundEvent.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(SoundEvent.class)
-public class MixinSoundEvent implements ExtendedForgeRegistryEntry<SoundEvent> {
+public class MixinSoundEvent implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public SoundEvent setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (SoundEvent) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinStatType.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinStatType.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(StatType.class)
-public class MixinStatType implements ExtendedForgeRegistryEntry<StatType> {
+public class MixinStatType implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public StatType setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (StatType) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinStatusEffect.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinStatusEffect.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(StatusEffect.class)
-public class MixinStatusEffect implements ExtendedForgeRegistryEntry<StatusEffect> {
+public class MixinStatusEffect implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public StatusEffect setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (StatusEffect) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinSurfaceBuilder.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinSurfaceBuilder.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(SurfaceBuilder.class)
-public class MixinSurfaceBuilder implements ExtendedForgeRegistryEntry<SurfaceBuilder> {
+public class MixinSurfaceBuilder implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public SurfaceBuilder setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (SurfaceBuilder) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {

--- a/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinVillagerProfession.java
+++ b/patchwork-registries/src/main/java/net/patchworkmc/mixin/registries/MixinVillagerProfession.java
@@ -19,6 +19,7 @@
 
 package net.patchworkmc.mixin.registries;
 
+import net.minecraftforge.registries.IForgeRegistryEntry;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
@@ -30,15 +31,15 @@ import net.patchworkmc.impl.registries.ExtendedForgeRegistryEntry;
 import net.patchworkmc.impl.registries.Identifiers;
 
 @Mixin(VillagerProfession.class)
-public class MixinVillagerProfession implements ExtendedForgeRegistryEntry<VillagerProfession> {
+public class MixinVillagerProfession implements ExtendedForgeRegistryEntry {
 	@Unique
 	private Identifier registryName;
 
 	@Override
-	public VillagerProfession setRegistryName(Identifier name) {
+	public IForgeRegistryEntry setRegistryName(Identifier name) {
 		this.registryName = name;
 
-		return (VillagerProfession) (Object) this;
+		return this;
 	}
 
 	public Identifier getRegistryName() {


### PR DESCRIPTION
Fixes the "TNT Yeeter" edge case that #141 can't replicate correctly. Changes the ExtendedForgeRegistryEntry generic from `<V>` to `<V extends IForgeRegistryEntry<V>>`, and converts all the Mixins to use raw types. I wrote a test mod and ran it over this and it was fine, but given how fragile replicating the ABI here has turned out to be, the more test cases the better.