### PR TITLE
Implement AnimalTameEvent

### DIFF
--- a/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
+++ b/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
@@ -50,4 +50,9 @@ public class AnimalTameEvent extends LivingEvent {
 	public PlayerEntity getTamer() {
 		return tamer;
 	}
+
+	@Override
+	public boolean isCancelable() {
+		return true;
+	}
 }

--- a/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
+++ b/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
@@ -1,0 +1,53 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.living;
+
+import net.minecraftforge.common.MinecraftForge;
+
+import net.minecraft.entity.passive.AnimalEntity;
+import net.minecraft.entity.player.PlayerEntity;
+
+/**
+ * This event is fired when an {@link AnimalEntity} is tamed.
+ *
+ * <p>It is fired via ForgeEventFactory#onAnimalTame(EntityAnimal, EntityPlayer).
+ * Forge fires this event for applicable vanilla animals, mods need to fire it themselves.
+ * This event is cancellable. If canceled, taming the animal will fail.
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+
+public class AnimalTameEvent extends LivingEvent {
+	private final AnimalEntity animal;
+	private final PlayerEntity tamer;
+
+	public AnimalTameEvent(AnimalEntity animal, PlayerEntity tamer) {
+		super(animal);
+		this.animal = animal;
+		this.tamer = tamer;
+	}
+
+	public AnimalEntity getAnimal() {
+		return animal;
+	}
+
+	public PlayerEntity getTamer() {
+		return tamer;
+	}
+}

--- a/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
+++ b/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
@@ -27,7 +27,7 @@ import net.minecraft.entity.player.PlayerEntity;
 /**
  * This event is fired when an {@link AnimalEntity} is tamed.
  *
- * <p>It is fired via ForgeEventFactory#onAnimalTame(EntityAnimal, EntityPlayer).
+ * <p>It is fired via ForgeEventFactory#onAnimalTame(AnimalEntity, PlayerEntity).
  * Forge fires this event for applicable vanilla animals, mods need to fire it themselves.
  * This event is cancellable. If canceled, taming the animal will fail.
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.

--- a/patchwork-events-entity/src/main/java/net/patchworkmc/impl/event/entity/EntityEvents.java
+++ b/patchwork-events-entity/src/main/java/net/patchworkmc/impl/event/entity/EntityEvents.java
@@ -26,6 +26,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.extensions.IForgeItem;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraftforge.event.entity.living.AnimalTameEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingDamageEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
@@ -54,6 +55,7 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.SpawnType;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
@@ -194,6 +196,10 @@ public class EntityEvents implements ModInitializer {
 
 	public static void onItemTooltip(ItemStack itemStack, PlayerEntity entityPlayer, List<Text> list, TooltipContext flags) {
 		MinecraftForge.EVENT_BUS.post(new ItemTooltipEvent(itemStack, entityPlayer, list, flags));
+	}
+
+	public static boolean onAnimalTame(AnimalEntity animal, PlayerEntity tamer) {
+		return MinecraftForge.EVENT_BUS.post(new AnimalTameEvent(animal, tamer));
 	}
 
 	@Override

--- a/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinHorseBondWithPlayerGoal.java
+++ b/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinHorseBondWithPlayerGoal.java
@@ -34,7 +34,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.patchworkmc.impl.event.entity.EntityEvents;
 
 @Mixin(HorseBondWithPlayerGoal.class)
-public class MixinHorseBoneWithPlayerGoal {
+public class MixinHorseBondWithPlayerGoal {
 	@Shadow
 	@Final
 	private HorseBaseEntity horse;

--- a/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinHorseBoneWithPlayerGoal.java
+++ b/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinHorseBoneWithPlayerGoal.java
@@ -1,0 +1,55 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.event.entity;
+
+import java.util.Random;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.entity.ai.goal.HorseBondWithPlayerGoal;
+import net.minecraft.entity.passive.HorseBaseEntity;
+import net.minecraft.entity.player.PlayerEntity;
+
+import net.patchworkmc.impl.event.entity.EntityEvents;
+
+@Mixin(HorseBondWithPlayerGoal.class)
+public class MixinHorseBoneWithPlayerGoal {
+	@Shadow
+	@Final
+	private HorseBaseEntity horse;
+
+	@Redirect(method = "tick", at = @At(value = "INVOKE", target = "Ljava/util/Random;nextInt(I)I", ordinal = 1))
+	private int redirectHorseBondWithPlayerCheck(Random random, int bound) {
+		int temper = horse.getTemper();
+		int nextInt = random.nextInt(bound);
+
+		if (nextInt < temper) {
+			if (EntityEvents.onAnimalTame(horse, (PlayerEntity) horse.getPassengerList().get(0))) {
+				return Integer.MAX_VALUE; // Force nextInt > temper
+			}
+		}
+
+		return nextInt;
+	}
+}

--- a/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinOcelotEntity.java
+++ b/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinOcelotEntity.java
@@ -40,7 +40,6 @@ public abstract class MixinOcelotEntity extends AnimalEntity {
 	protected MixinOcelotEntity() {
 		//noinspection ConstantConditions
 		super(null, null);
-		throw new IllegalStateException("Created instance of a Mixin, you're doing something wrong!");
 	}
 
 	@Inject(method = "interactMob", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/OcelotEntity;setTrusting(Z)V"), cancellable = true)

--- a/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinOcelotEntity.java
+++ b/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinOcelotEntity.java
@@ -1,0 +1,54 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.event.entity;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.entity.passive.AnimalEntity;
+import net.minecraft.entity.passive.OcelotEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Hand;
+
+import net.patchworkmc.impl.event.entity.EntityEvents;
+
+@Mixin(OcelotEntity.class)
+public abstract class MixinOcelotEntity extends AnimalEntity {
+	@Shadow
+	protected abstract void showEmoteParticle(boolean positive);
+
+	protected MixinOcelotEntity() {
+		//noinspection ConstantConditions
+		super(null, null);
+		throw new IllegalStateException("Created instance of a Mixin, you're doing something wrong!");
+	}
+
+	@Inject(method = "interactMob", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/OcelotEntity;setTrusting(Z)V"), cancellable = true)
+	private void onOcelotTrusting(PlayerEntity player, Hand hand, CallbackInfoReturnable<Boolean> cir) {
+		if (EntityEvents.onAnimalTame(this, player)) {
+			this.showEmoteParticle(false);
+			this.world.sendEntityStatus(this, (byte) 40);
+			cir.setReturnValue(true);
+		}
+	}
+}

--- a/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinTameableEntitySubclass.java
+++ b/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinTameableEntitySubclass.java
@@ -1,0 +1,52 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.mixin.event.entity;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.entity.passive.ParrotEntity;
+import net.minecraft.entity.passive.TameableEntity;
+import net.minecraft.entity.passive.WolfEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Hand;
+
+import net.patchworkmc.impl.event.entity.EntityEvents;
+
+// CatEntity is intentionally omitted. See MinecraftForge/#7171
+@Mixin({ParrotEntity.class, WolfEntity.class})
+public abstract class MixinTameableEntitySubclass extends TameableEntity {
+	protected MixinTameableEntitySubclass() {
+		//noinspection ConstantConditions
+		super(null, null);
+		throw new IllegalStateException("Created instance of a Mixin, you're doing something wrong!");
+	}
+
+	@Inject(method = "interactMob", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/TameableEntity;setOwner(Lnet/minecraft/entity/player/PlayerEntity;)V"), cancellable = true)
+	private void onTamedMob(PlayerEntity player, Hand hand, CallbackInfoReturnable<Boolean> cir) {
+		if (EntityEvents.onAnimalTame(this, player)) {
+			this.showEmoteParticle(false);
+			this.world.sendEntityStatus(this, (byte) 6);
+			cir.setReturnValue(true);
+		}
+	}
+}

--- a/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinTameableEntitySubclass.java
+++ b/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinTameableEntitySubclass.java
@@ -38,7 +38,6 @@ public abstract class MixinTameableEntitySubclass extends TameableEntity {
 	protected MixinTameableEntitySubclass() {
 		//noinspection ConstantConditions
 		super(null, null);
-		throw new IllegalStateException("Created instance of a Mixin, you're doing something wrong!");
 	}
 
 	@Inject(method = "interactMob", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/TameableEntity;setOwner(Lnet/minecraft/entity/player/PlayerEntity;)V"), cancellable = true)

--- a/patchwork-events-entity/src/main/resources/patchwork-events-entity.mixins.json
+++ b/patchwork-events-entity/src/main/resources/patchwork-events-entity.mixins.json
@@ -7,7 +7,7 @@
     "MixinEntityTrackerEntry",
     "MixinEntityType",
     "MixinExperienceOrbEntity",
-    "MixinHorseBoneWithPlayerGoal",
+    "MixinHorseBondWithPlayerGoal",
     "MixinLivingEntity",
     "MixinMobEntity",
     "MixinMobSpawnerLogic",

--- a/patchwork-events-entity/src/main/resources/patchwork-events-entity.mixins.json
+++ b/patchwork-events-entity/src/main/resources/patchwork-events-entity.mixins.json
@@ -7,19 +7,22 @@
     "MixinEntityTrackerEntry",
     "MixinEntityType",
     "MixinExperienceOrbEntity",
+    "MixinHorseBoneWithPlayerGoal",
     "MixinLivingEntity",
     "MixinMobEntity",
     "MixinMobSpawnerLogic",
+    "MixinOcelotEntity",
     "MixinPlayerEntity",
     "MixinPlayerManager",
     "MixinServerPlayerEntity",
     "MixinServerWorld",
     "MixinSpawnHelper",
+    "MixinTameableEntitySubclass",
     "MixinWorldChunk"
   ],
   "client": [
-    "MixinClientWorld",
     "MixinClientPlayerEntity",
+    "MixinClientWorld",
     "MixinItemStack",
     "MixinOtherClientPlayerEntity"
   ],

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -27,6 +27,7 @@ import net.minecraftforge.eventbus.api.Event;
 
 import net.minecraft.entity.SpawnType;
 import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.loot.LootManager;
 import net.minecraft.loot.LootTable;
@@ -81,5 +82,9 @@ public class ForgeEventFactory {
 
 	public static float fireBlockHarvesting(DefaultedList<ItemStack> drops, World world, BlockPos pos, BlockState state, int fortune, float dropChance, boolean silkTouch, PlayerEntity player) {
 		return WorldEvents.fireBlockHarvesting(drops, world, pos, state, fortune, dropChance, silkTouch, player);
+	}
+
+	public static boolean onAnimalTame(AnimalEntity animal, PlayerEntity tamer) {
+		return EntityEvents.onAnimalTame(animal, tamer);
 	}
 }


### PR DESCRIPTION
TNT Yeeter needs this (specifically the ForgeEventFactory method for it) to not crash when taming a TNT Yeeter. The event is intentionally not fired when taming a CatEntity because of MinecraftForge/MinecraftForge#7171.