### PR TITLE
Add classes and fields to ForgeHooks, which might be used by hacky mods

### DIFF
--- a/patchwork-god-classes/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -105,6 +105,16 @@ public class ForgeHooks {
 		return EntityEvents.attackEntity(player, target);
 	}
 
+	@SuppressWarnings({ "rawtypes", "unused" })
+	private static ThreadLocal<?> lootContext = LootHooks.lootContext;
+
+	// Need to have the class here to make some mod hacks work
+	public static class LootTableContext extends LootHooks.LootTableContext {
+		private LootTableContext(Identifier name, boolean custom) {
+			super(name, custom);
+		}
+	}
+
 	@Nullable
 	public static LootTable loadLootTable(Gson gson, Identifier name, JsonObject data, boolean custom, LootManager lootTableManager) {
 		return LootHooks.loadLootTable(gson, name, data, custom, lootTableManager);

--- a/patchwork-loot/src/main/java/net/patchworkmc/impl/loot/LootHooks.java
+++ b/patchwork-loot/src/main/java/net/patchworkmc/impl/loot/LootHooks.java
@@ -30,7 +30,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import org.spongepowered.asm.mixin.Unique;
 
 import net.minecraft.loot.LootManager;
 import net.minecraft.loot.LootTable;
@@ -41,8 +40,8 @@ import net.patchworkmc.impl.event.loot.LootEvents;
 
 // NOTE: this class is more or less a direct copy of parts of Forge's ForgeHooks.
 public class LootHooks {
-	@Unique
-	private static ThreadLocal<Deque<LootTableContext>> lootContext = new ThreadLocal<Deque<LootTableContext>>();
+	// Made public for Patchwork's own use
+	public static ThreadLocal<Deque<LootTableContext>> lootContext = new ThreadLocal<Deque<LootTableContext>>();
 
 	public static LootTable loadLootTable(Gson gson, Identifier name, JsonElement data, boolean custom, LootManager lootTableManager) {
 		Deque<LootTableContext> que = lootContext.get();
@@ -105,7 +104,8 @@ public class LootHooks {
 		return ctx.poolCount == 1 ? "main" : "pool" + (ctx.poolCount - 1);
 	}
 
-	private static class LootTableContext {
+	// Made public for Patchwork's own use
+	public static class LootTableContext {
 		public final Identifier name;
 		public final boolean custom;
 		private final boolean vanilla;
@@ -113,7 +113,7 @@ public class LootHooks {
 		public int entryCount = 0;
 		private HashSet<String> entryNames = Sets.newHashSet();
 
-		private LootTableContext(Identifier name, boolean custom) {
+		protected LootTableContext(Identifier name, boolean custom) {
 			this.name = name;
 			this.custom = custom;
 			this.vanilla = "minecraft".equals(this.name.getNamespace());


### PR DESCRIPTION
This fix makes https://github.com/MinecraftModDevelopmentMods/AdditionalLootTables/tree/master-1.15.2 work.
By design, AdditionalLootTables 1.15.2 should also work in 1.14.4. Without coremoding, in order to append items to an existing loottable, Forge mods have to use reflection on `ForgeHooks.lootContext`.