### PR TITLE
Make CapabilityRegisteredCallback store class names not class objects

### DIFF
--- a/patchwork-capabilities/src/main/java/net/patchworkmc/api/capability/CapabilityRegisteredCallback.java
+++ b/patchwork-capabilities/src/main/java/net/patchworkmc/api/capability/CapabilityRegisteredCallback.java
@@ -29,6 +29,10 @@ public interface CapabilityRegisteredCallback<C> {
 	void onCapabilityRegistered(Capability<C> capability);
 
 	static <C> Event<CapabilityRegisteredCallback<C>> event(Class<C> type) {
-		return CapabilityRegisteredCallbackInternal.getOrCreateEvent(type);
+		return CapabilityRegisteredCallbackInternal.getOrCreateEvent(type.getName());
+	}
+
+	static <C> Event<CapabilityRegisteredCallback<C>> event(String className) {
+		return CapabilityRegisteredCallbackInternal.getOrCreateEvent(className);
 	}
 }

--- a/patchwork-capabilities/src/main/java/net/patchworkmc/impl/capability/CapabilityRegisteredCallbackInternal.java
+++ b/patchwork-capabilities/src/main/java/net/patchworkmc/impl/capability/CapabilityRegisteredCallbackInternal.java
@@ -19,7 +19,7 @@
 
 package net.patchworkmc.impl.capability;
 
-import java.util.IdentityHashMap;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
@@ -33,10 +33,10 @@ import net.patchworkmc.api.capability.CapabilityRegisteredCallback;
 public class CapabilityRegisteredCallbackInternal {
 	private static final Logger LOGGER = LogManager.getLogger(CapabilityRegisteredCallback.class);
 
-	private static final Map<Class<?>, Event<?>> CALLBACKS = new IdentityHashMap<>();
+	private static final Map<String, Event<?>> CALLBACKS = new HashMap<>();
 
 	@SuppressWarnings("unchecked")
-	public static <C> Event<CapabilityRegisteredCallback<C>> getOrCreateEvent(Class<C> type) {
+	public static <C> Event<CapabilityRegisteredCallback<C>> getOrCreateEvent(String type) {
 		return (Event<CapabilityRegisteredCallback<C>>) CALLBACKS.computeIfAbsent(type, $ -> EventFactory.createArrayBacked(CapabilityRegisteredCallback.class, capability -> { }, callbacks -> capability -> {
 			boolean error = false;
 			Throwable throwable = new Throwable();
@@ -51,7 +51,7 @@ public class CapabilityRegisteredCallbackInternal {
 			}
 
 			if (error) {
-				LOGGER.error("An uncaught exception was thrown while processing a CapabilityRegisteredCallback<{}>", type.getName(), throwable);
+				LOGGER.error("An uncaught exception was thrown while processing a CapabilityRegisteredCallback<{}>", type, throwable);
 			}
 		}));
 	}


### PR DESCRIPTION
This is needed so the CapabilityInject handling in Patcher doesn't have to load types onto the stack, and replicate Forge behavior of not needing a CapabilityInject's type to exist at runtime.