### PR TITLE
Add ChunkEvent

### DIFF
--- a/patchwork-events-world/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
+++ b/patchwork-events-world/src/main/java/net/minecraftforge/event/world/ChunkEvent.java
@@ -1,0 +1,93 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.world;
+
+import net.minecraftforge.common.MinecraftForge;
+
+import net.minecraft.world.IWorld;
+import net.minecraft.world.chunk.Chunk;
+
+import net.patchworkmc.impl.event.world.WorldEvents;
+
+/**
+ * ChunkEvent is fired when an event involving a chunk occurs.<br>
+ * If a method utilizes this {@link net.minecraftforge.eventbus.api.Event} as
+ * its parameter, the method will receive every child event of this class.<br>
+ * <br>
+ * {@link #Chunk} contains the Chunk this event is affecting.<br>
+ * <br>
+ * All children of this event are fired on the
+ * {@link MinecraftForge#EVENT_BUS}.<br>
+ */
+public class ChunkEvent extends WorldEvent {
+	private final Chunk chunk;
+
+	public ChunkEvent(Chunk chunk) {
+		super(WorldEvents.getWorldForChunk(chunk));
+		this.chunk = chunk;
+	}
+
+	public ChunkEvent(Chunk chunk, IWorld world) {
+		super(world);
+		this.chunk = chunk;
+	}
+
+	public Chunk getChunk() {
+		return chunk;
+	}
+
+	/**
+	 * ChunkEvent.Load is fired when vanilla Minecraft attempts to load a Chunk into
+	 * the world.<br>
+	 * This event is fired during chunk loading in <br>
+	 * {@link ChunkProviderClient#loadChunk(int, int)}, <br>
+	 * Chunk.onChunkLoad(). <br>
+	 * <br>
+	 * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+	 * <br>
+	 * This event does not have a result. {@link HasResult} <br>
+	 * <br>
+	 * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+	 */
+	public static class Load extends ChunkEvent {
+		public Load(Chunk chunk) {
+			super(chunk);
+		}
+	}
+
+	/**
+	 * ChunkEvent.Unload is fired when vanilla Minecraft attempts to unload a Chunk
+	 * from the world.<br>
+	 * This event is fired during chunk unloading in <br>
+	 * Chunk.onChunkUnload(). <br>
+	 * <br>
+	 * This event is not {@link net.minecraftforge.eventbus.api.Cancelable}.<br>
+	 * <br>
+	 * This event does not have a result. {@link HasResult} <br>
+	 * <br>
+	 * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+	 */
+	public static class Unload extends ChunkEvent {
+		public Unload(Chunk chunk) {
+			super(chunk);
+		}
+	}
+}
+

--- a/patchwork-events-world/src/main/java/net/patchworkmc/impl/event/world/WorldEventsClient.java
+++ b/patchwork-events-world/src/main/java/net/patchworkmc/impl/event/world/WorldEventsClient.java
@@ -33,6 +33,7 @@ public class WorldEventsClient implements ClientModInitializer {
 		///////////////////////////////////////////////
 		ClientChunkEvents.CHUNK_LOAD.register((server, chunk) -> MinecraftForge.EVENT_BUS.post(new ChunkEvent.Load(chunk)));
 		ClientChunkEvents.CHUNK_UNLOAD.register((server, chunk) -> MinecraftForge.EVENT_BUS.post(new ChunkEvent.Unload(chunk)));
+		// Fabric fires the chunk unload event after it's been removed from the client's chunk graph. This probably won't cause any issues.
 		/* ClientChunkManager.unload(II)V
 		 * if (method_20181(chunk, x, z)) {
 		 *     net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkEvent.Unload(chunk));

--- a/patchwork-events-world/src/main/java/net/patchworkmc/impl/event/world/WorldEventsClient.java
+++ b/patchwork-events-world/src/main/java/net/patchworkmc/impl/event/world/WorldEventsClient.java
@@ -1,0 +1,44 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.impl.event.world;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.ChunkEvent;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientChunkEvents;
+
+public class WorldEventsClient implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		///////////////////////////////////////////////
+		/// ChunkEvent.Load and Unload on client side
+		///////////////////////////////////////////////
+		ClientChunkEvents.CHUNK_LOAD.register((server, chunk) -> MinecraftForge.EVENT_BUS.post(new ChunkEvent.Load(chunk)));
+		ClientChunkEvents.CHUNK_UNLOAD.register((server, chunk) -> MinecraftForge.EVENT_BUS.post(new ChunkEvent.Unload(chunk)));
+		/* ClientChunkManager.unload(II)V
+		 * if (method_20181(chunk, x, z)) {
+		 *     net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkEvent.Unload(chunk));
+		 *     this.chunks.method_20183(i, chunk, (WorldChunk)null);
+		 *     ClientChunkEvents.CHUNK_UNLOAD
+		 * }
+		 */
+	}
+}

--- a/patchwork-events-world/src/main/java/net/patchworkmc/mixin/event/world/MixinThreadedAnvilChunkStorage.java
+++ b/patchwork-events-world/src/main/java/net/patchworkmc/mixin/event/world/MixinThreadedAnvilChunkStorage.java
@@ -22,14 +22,21 @@ package net.patchworkmc.mixin.event.world;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.At.Shift;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.ChunkEvent;
 
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Packet;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.server.world.ThreadedAnvilChunkStorage;
 import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.chunk.Chunk;
 
 import net.patchworkmc.impl.event.world.WorldEvents;
 
@@ -43,5 +50,17 @@ public class MixinThreadedAnvilChunkStorage {
 		if (this.world == player.world && withinMaxWatchDistance != withinViewDistance) {
 			WorldEvents.fireChunkWatch(withinViewDistance, player, pos, this.world);
 		}
+	}
+
+	// Lambda in "private CompletableFuture<Either<Chunk, Unloaded>> method_20619(ChunkPos chunkPos)"
+	//   chunk.setLastSaveTime(this.world.getTime());
+	// + MinecraftForge.EVENT_BUS.post(new ChunkEvent.Load(chunk));
+	//   return Either.left(chunk);
+	@SuppressWarnings("rawtypes")
+	@Inject(method = "method_17256", locals = LocalCapture.CAPTURE_FAILHARD, at = @At(value = "INVOKE", shift = Shift.AFTER, ordinal = 0, target =
+			"net/minecraft/world/chunk/Chunk.setLastSaveTime(J)V"))
+	public void onServerChunkLoad(ChunkPos chunkPos, CallbackInfoReturnable cir, CompoundTag compoundTag, boolean bl, Chunk chunk) {
+		// Fire ChunkEvent.Load on server side
+		MinecraftForge.EVENT_BUS.post(new ChunkEvent.Load(chunk));
 	}
 }

--- a/patchwork-events-world/src/main/resources/fabric.mod.json
+++ b/patchwork-events-world/src/main/resources/fabric.mod.json
@@ -15,6 +15,14 @@
   "depends": {
     "patchwork-api-base": "*"
   },
+  "entrypoints": {
+    "main": [
+      "net.patchworkmc.impl.event.world.WorldEvents"
+    ],
+    "client": [
+      "net.patchworkmc.impl.event.world.WorldEventsClient"
+    ]
+  },
   "mixins": [
     "patchwork-events-world.mixins.json"
   ],


### PR DESCRIPTION
Implements ChunkEvent.Load and ChunkEvent.Unload events.

Most of these events are backed with the corresponding Fabric events, except for ChunkEvent.Load, which needs 1 extra mixin.