### PR TITLE
Fix item pickup events

### DIFF
--- a/patchwork-events-entity/src/main/java/net/patchworkmc/impl/event/entity/PlayerEvents.java
+++ b/patchwork-events-entity/src/main/java/net/patchworkmc/impl/event/entity/PlayerEvents.java
@@ -61,7 +61,7 @@ public class PlayerEvents {
 
 	/**
 	 *
-	 * @return -1 if the event was cancelled, 0 if the event was denied, 1 if the event was accepted
+	 * @return -1 if the event was canceled, 0 if the event was denied or had no result set, and 1 if the event was allowed
 	 */
 	public static int onItemPickup(PlayerEntity player, ItemEntity entityItem) {
 		Event event = new EntityItemPickupEvent(player, entityItem);

--- a/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinItemEntity.java
+++ b/patchwork-events-entity/src/main/java/net/patchworkmc/mixin/event/entity/MixinItemEntity.java
@@ -20,6 +20,8 @@
 package net.patchworkmc.mixin.event.entity;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.At.Shift;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -35,34 +37,73 @@ import net.patchworkmc.impl.event.entity.PlayerEvents;
 
 @Mixin(ItemEntity.class)
 public abstract class MixinItemEntity {
-	@Inject(method = "onPlayerCollision",
-			at = @At(
-					value = "INVOKE",
-					shift = Shift.BEFORE,
-					ordinal = 0,
-					target = "net/minecraft/item/ItemStack.isEmpty()Z"
-					)
-	)
-	private void onPlayerPickUpItemEntity(PlayerEntity player, CallbackInfo ci) {
-		ItemEntity me = (ItemEntity) (Object) this;
-		PlayerEvents.firePlayerItemPickupEvent(player, me, me.getStack().copy());
+	@Shadow
+	public abstract ItemStack getStack();
+
+	@Shadow
+	private int pickupDelay;
+
+	@Unique
+	private int eventResult;
+
+	@Unique
+	private int preEventStackCount;
+
+	@Unique
+	private ItemStack copy;
+
+	// Forge just returns early from the event if the item has pickup delay, presumably
+	// to keep it's events from being called. To maintain compatibility with potential
+	// Fabric mods that might want to still have this method called from items that can't
+	// be picked up yet, we'll just skip calling the events.
+	@Unique
+	private boolean hasPickupDelay;
+
+	@Inject(method = "onPlayerCollision", at = @At("HEAD"), cancellable = true)
+	private void patchwork_checkForPickupDelay(PlayerEntity player, CallbackInfo ci) {
+		hasPickupDelay = this.pickupDelay > 0;
 	}
 
-	int eventResult;
-
 	@Inject(method = "onPlayerCollision",
-			at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getCount()I"),
-			cancellable = true
+					at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getCount()I"),
+					cancellable = true
 	)
-	void patchwork_fireItemPickupEvent(PlayerEntity player, CallbackInfo ci) {
-		eventResult = PlayerEvents.onItemPickup(player, (ItemEntity) (Object) this);
-		if (eventResult != 1) ci.cancel();
+	private void patchwork_fireItemPickupEvent(PlayerEntity player, CallbackInfo ci) {
+		if (!hasPickupDelay) {
+			preEventStackCount = getStack().getCount();
+			eventResult = PlayerEvents.onItemPickup(player, (ItemEntity) (Object) this);
+
+			if (eventResult < 0) {
+				ci.cancel();
+			}
+
+			copy = getStack().copy();
+		}
 	}
 
 	@Redirect(method = "onPlayerCollision",
-			at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;insertStack(Lnet/minecraft/item/ItemStack;)Z")
+					at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;insertStack(Lnet/minecraft/item/ItemStack;)Z")
 	)
-	boolean patchwork_skipIfEventNotAllowed(PlayerInventory playerInventory, ItemStack stack) {
-		return eventResult == 1 || playerInventory.insertStack(stack);
+	private boolean patchwork_giveItemConditions(PlayerInventory playerInventory, ItemStack stack) {
+		if (hasPickupDelay) {
+			return playerInventory.insertStack(stack); // Haven't processed the event because Forge wouldn't.
+		} else {
+			return eventResult == 1 || preEventStackCount <= 0 || playerInventory.insertStack(stack);
+		}
+	}
+
+	@Inject(method = "onPlayerCollision",
+					at = @At(
+									value = "INVOKE",
+									shift = Shift.BEFORE,
+									ordinal = 0,
+									target = "net/minecraft/item/ItemStack.isEmpty()Z"
+					)
+	)
+	private void patchwork_firePlayerItemPickupEvent(PlayerEntity player, CallbackInfo ci) {
+		if (!hasPickupDelay) {
+			copy.setCount(copy.getCount() - getStack().getCount());
+			PlayerEvents.firePlayerItemPickupEvent(player, (ItemEntity) (Object) this, copy);
+		}
 	}
 }


### PR DESCRIPTION
EntityItemPickupEvent and PlayerEvent.ItemPickupEvent were implemented incorrectly, leading to no items being able to be picked up and events firing at times they shouldn't. This PR fixes the implementation of these two events.