### PR TITLE
Allow for subprojects that aren't fabric mods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,6 @@ javadoc {
 	classpath = sourceSets.main.compileClasspath
 }
 
-//subprojects.each { bintrayUpload.dependsOn("${it.path}:bintrayUpload") }
-
 bintray {
 	user = project.hasProperty('bintrayUser') ? project.getProperty('bintrayUser') : System.getenv('bintray_user')
 	key = project.hasProperty('bintrayKey') ? project.getProperty('bintrayKey') : System.getenv('bintray_key')
@@ -109,7 +107,6 @@ publishing {
 }
 
 task licenseFormatAll
-//subprojects.each {remapJar.dependsOn("${it.path}:remapJar")}
 
 repositories {
 	flatDir {
@@ -120,13 +117,6 @@ repositories {
 }
 
 dependencies {
-	afterEvaluate {
-		subprojects.each {
-			compile project(path: ":${it.name}", configuration: "dev")
-			include project("${it.name}:")
-		}
-	}
-
 	minecraft "com.mojang:minecraft:$project.mcVersion"
 	mappings "net.fabricmc:yarn:${project.mcVersion}${project.yarnVersion}:v2"
 	modImplementation "net.fabricmc:fabric-loader:0.10.0+build.208"

--- a/build.gradle
+++ b/build.gradle
@@ -3,20 +3,17 @@ plugins {
 	id 'eclipse'
 	id 'idea'
 	id 'maven-publish'
-	id 'fabric-loom' version '0.5-SNAPSHOT' apply false
+	//id 'fabric-loom' /* version '0.5-SNAPSHOT' */ apply false
 	id 'net.minecrell.licenser' version '0.4.1'
 	id "org.ajoberstar.grgit" version "3.1.1"
 	id 'com.jfrog.bintray' version '1.8.4'
+	id 'patchwork-api.module-conventions'
+	id "com.dorongold.task-tree" version "1.5"
 }
 
 def ENV = System.getenv()
 
-class Globals {
-	static def baseVersion = "0.10.0"
-	static def mcVersion = "1.14.4"
-	static def yarnVersion = "+build.16"
-}
-version = Globals.baseVersion //+ "+" + (ENV.BUILD_NUMBER ? ("build." + ENV.BUILD_NUMBER) : "local") + "-" + getBranch()
+version = project.baseVersion //+ "+" + (ENV.BUILD_NUMBER ? ("build." + ENV.BUILD_NUMBER) : "local") + "-" + getBranch()
 
 logger.lifecycle("Building Patchwork: " + version)
 
@@ -44,86 +41,6 @@ def getBranch() {
 	return branch.substring(branch.lastIndexOf("/") + 1)
 }
 
-allprojects {
-	apply plugin: 'checkstyle'
-	apply plugin: 'maven-publish'
-	apply plugin: 'fabric-loom'
-	apply plugin: 'net.minecrell.licenser'
-	apply plugin: 'com.jfrog.bintray'
-	sourceCompatibility = 1.8
-	targetCompatibility = 1.8
-
-	group = "net.patchworkmc.patchwork-api"
-
-	loom {
-		shareCaches = true
-	}
-
-	repositories {
-		maven { url 'https://dl.bintray.com/patchworkmc/Patchwork-Maven/' }
-	}
-
-	dependencies {
-		minecraft "com.mojang:minecraft:$Globals.mcVersion"
-		mappings "net.fabricmc:yarn:${Globals.mcVersion}${Globals.yarnVersion}:v2"
-		modImplementation "net.fabricmc:fabric-loader:0.10.0+build.208"
-		modImplementation "net.fabricmc.fabric-api:fabric-api:0.15.1+build.260-1.14"
-
-		implementation 'net.patchworkmc:patchwork-eventbus:2.0.1:all'
-		implementation 'com.google.code.findbugs:jsr305:3.0.2'
-
-		// For EventBus
-		implementation 'net.jodah:typetools:0.6.0'
-	}
-
-	configurations {
-		dev
-	}
-
-	jar {
-		classifier = "dev"
-	}
-
-	afterEvaluate {
-		remapJar {
-			input = file("${project.buildDir}/libs/$archivesBaseName-${version}-dev.jar")
-			archiveName = "${archivesBaseName}-${version}.jar"
-		}
-
-		artifacts {
-			dev file: file("${project.buildDir}/libs/$archivesBaseName-${version}-dev.jar"), type: "jar", builtBy: jar
-		}
-
-		processResources {
-			inputs.property "version", project.version
-
-			from(sourceSets.main.resources.srcDirs) {
-				include "fabric.mod.json"
-				expand "version": project.version
-			}
-
-			from(sourceSets.main.resources.srcDirs) {
-				exclude "fabric.mod.json"
-			}
-		}
-
-		license {
-			header rootProject.file('HEADER')
-			include '**/*.java'
-		}
-	}
-
-	task sourcesJar(type: Jar, dependsOn: classes) {
-		classifier = 'sources'
-		from sourceSets.main.allSource
-	}
-
-	checkstyle {
-		configFile = rootProject.file("checkstyle.xml")
-		toolVersion = '8.36.2'
-	}
-}
-
 javadoc {
 	options.memberLevel = "PACKAGE"
 	allprojects.each {
@@ -132,60 +49,7 @@ javadoc {
 	classpath = sourceSets.main.compileClasspath
 }
 
-subprojects {
-	task remapMavenJar(type: Copy, dependsOn: remapJar) {
-		afterEvaluate {
-			from("${project.buildDir}/libs/$archivesBaseName-${version}.jar")
-			into("${project.buildDir}/libs/")
-			rename {String fn -> "$archivesBaseName-${version}-maven.jar"}
-		}
-	}
-
-	publishing {
-		publications {
-			create("${archivesBaseName}_mavenJava", MavenPublication) {
-				afterEvaluate {
-					artifact(file("${project.buildDir}/libs/$archivesBaseName-${version}-maven.jar")) {
-						builtBy remapMavenJar
-					}
-					artifact(sourcesJar) {
-						builtBy remapSourcesJar
-					}
-				}
-			}
-		}
-	}
-
-	bintray {
-		user = project.hasProperty('bintrayUser') ? project.getProperty('bintrayUser') : System.getenv('bintray_user')
-		key = project.hasProperty('bintrayKey') ? project.getProperty('bintrayKey') : System.getenv('bintray_key')
-		publish = true
-		override = true
-		publications = ["${archivesBaseName}_mavenJava"]
-		pkg {
-			repo = project.bintrayRepo
-			name = archivesBaseName
-			user = bintray.user
-			userOrg = project.repoOwner
-			licenses = [project.codeLicense]
-			desc = project.description
-			websiteUrl = "https://github.com/${project.repoOwner}/${project.repoName}"
-			issueTrackerUrl = "https://github.com/${project.repoOwner}/${project.repoName}/issues"
-			vcsUrl = "https://github.com/${project.repoOwner}/${project.repoName}.git"
-			publicDownloadNumbers = true
-
-			githubRepo = "${project.repoOwner}/${project.repoName}"
-			version {
-				name = project.version
-				released = new Date()
-			}
-		}
-	}
-
-	javadoc.enabled = false
-}
-
-subprojects.each { bintrayUpload.dependsOn("${it.path}:bintrayUpload") }
+//subprojects.each { bintrayUpload.dependsOn("${it.path}:bintrayUpload") }
 
 bintray {
 	user = project.hasProperty('bintrayUser') ? project.getProperty('bintrayUser') : System.getenv('bintray_user')
@@ -247,8 +111,7 @@ publishing {
 }
 
 task licenseFormatAll
-subprojects {p -> licenseFormatAll.dependsOn("${p.path}:licenseFormat")}
-subprojects.each {remapJar.dependsOn("${it.path}:remapJar")}
+//subprojects.each {remapJar.dependsOn("${it.path}:remapJar")}
 
 repositories {
 	flatDir {
@@ -259,15 +122,15 @@ repositories {
 }
 
 dependencies {
-	afterEvaluate {
+//	afterEvaluate {
 		subprojects.each {
 			compile project(path: ":${it.name}", configuration: "dev")
 			include project("${it.name}:")
 		}
-	}
+//	}
 
-	minecraft "com.mojang:minecraft:$Globals.mcVersion"
-	mappings "net.fabricmc:yarn:${Globals.mcVersion}${Globals.yarnVersion}:v2"
+	minecraft "com.mojang:minecraft:$project.mcVersion"
+	mappings "net.fabricmc:yarn:${project.mcVersion}${project.yarnVersion}:v2"
 	modImplementation "net.fabricmc:fabric-loader:0.10.0+build.208"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:0.15.1+build.260-1.14"
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,10 @@ plugins {
 	id 'eclipse'
 	id 'idea'
 	id 'maven-publish'
-	//id 'fabric-loom' /* version '0.5-SNAPSHOT' */ apply false
 	id 'net.minecrell.licenser' version '0.4.1'
 	id "org.ajoberstar.grgit" version "3.1.1"
 	id 'com.jfrog.bintray' version '1.8.4'
 	id 'patchwork-api.module-conventions'
-	id "com.dorongold.task-tree" version "1.5"
 }
 
 def ENV = System.getenv()
@@ -122,12 +120,12 @@ repositories {
 }
 
 dependencies {
-//	afterEvaluate {
+	afterEvaluate {
 		subprojects.each {
 			compile project(path: ":${it.name}", configuration: "dev")
 			include project("${it.name}:")
 		}
-//	}
+	}
 
 	minecraft "com.mojang:minecraft:$project.mcVersion"
 	mappings "net.fabricmc:yarn:${project.mcVersion}${project.yarnVersion}:v2"
@@ -138,10 +136,6 @@ dependencies {
 	include 'com.electronwill.night-config:core:3.6.2'
 	include 'com.electronwill.night-config:toml:3.6.2'
 	include 'net.patchworkmc:patchwork-eventbus:2.0.0:all'
-}
-
-loom {
-	shareCaches = true
 }
 
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,6 +9,7 @@ repositories {
 		name = 'Fabric'
 		url = 'https://maven.fabricmc.net/'
 	}
+	mavenLocal()
 }
 
 dependencies {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'groovy-gradle-plugin'
+}
+
+repositories {
+	mavenCentral()
+	maven { url 'https://dl.bintray.com/patchworkmc/Patchwork-Maven/' }
+	maven {
+		name = 'Fabric'
+		url = 'https://maven.fabricmc.net/'
+	}
+}
+
+dependencies {
+	implementation 'net.fabricmc:fabric-loom:0.5-SNAPSHOT'
+}

--- a/buildSrc/src/main/groovy/patchwork-api.module-conventions.gradle
+++ b/buildSrc/src/main/groovy/patchwork-api.module-conventions.gradle
@@ -1,0 +1,83 @@
+plugins {
+//	id 'java'
+//	id 'eclipse'
+//	id 'idea'
+	id 'checkstyle'
+	id 'maven-publish'
+	id 'fabric-loom'
+	id 'net.minecrell.licenser' //version '0.4.1'
+	id 'com.jfrog.bintray' //version '1.8.4'
+}
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+group = "net.patchworkmc.patchwork-api"
+
+loom {
+	shareCaches = true
+}
+
+repositories {
+	maven { url 'https://dl.bintray.com/patchworkmc/Patchwork-Maven/' }
+}
+
+dependencies {
+	minecraft "com.mojang:minecraft:$rootProject.mcVersion"
+	mappings "net.fabricmc:yarn:${rootProject.mcVersion}${rootProject.yarnVersion}:v2"
+	modImplementation "net.fabricmc:fabric-loader:0.10.0+build.208"
+	modImplementation "net.fabricmc.fabric-api:fabric-api:0.15.1+build.260-1.14"
+
+	implementation 'net.patchworkmc:patchwork-eventbus:2.0.1:all'
+	implementation 'com.google.code.findbugs:jsr305:3.0.2'
+
+	// For EventBus
+	implementation 'net.jodah:typetools:0.6.0'
+}
+
+configurations {
+	dev
+}
+
+jar {
+	classifier = "dev"
+}
+
+afterEvaluate {
+	remapJar {
+		input = file("${project.buildDir}/libs/$archivesBaseName-${version}-dev.jar")
+		archiveName = "${archivesBaseName}-${version}.jar"
+	}
+
+	artifacts {
+		dev file: file("${project.buildDir}/libs/$archivesBaseName-${version}-dev.jar"), type: "jar", builtBy: jar
+	}
+
+	processResources {
+		inputs.property "version", project.version
+
+		from(project.sourceSets.main.resources.srcDirs) {
+			include "fabric.mod.json"
+			expand "version": project.version
+		}
+
+		from(project.sourceSets.main.resources.srcDirs) {
+			exclude "fabric.mod.json"
+		}
+	}
+
+	license {
+		header rootProject.file('HEADER')
+		include '**/*.java'
+	}
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+	classifier = 'sources'
+	from project.sourceSets.main.allSource
+}
+
+checkstyle {
+	configFile = rootProject.file("checkstyle.xml")
+	toolVersion = '8.36.2'
+}

--- a/buildSrc/src/main/groovy/patchwork-api.submodule-conventions.gradle
+++ b/buildSrc/src/main/groovy/patchwork-api.submodule-conventions.gradle
@@ -1,0 +1,60 @@
+plugins {
+	id 'patchwork-api.module-conventions'
+}
+
+task remapMavenJar(type: Copy, dependsOn: remapJar) {
+	afterEvaluate {
+		from("${project.buildDir}/libs/$archivesBaseName-${version}.jar")
+		into("${project.buildDir}/libs/")
+		rename {String fn -> "$archivesBaseName-${version}-maven.jar"}
+	}
+}
+
+publishing {
+	publications {
+		create("${archivesBaseName}_mavenJava", MavenPublication) {
+			afterEvaluate {
+				artifact(file("${project.buildDir}/libs/$archivesBaseName-${version}-maven.jar")) {
+					builtBy remapMavenJar
+				}
+				artifact(sourcesJar) {
+					builtBy remapSourcesJar
+				}
+			}
+		}
+	}
+}
+
+bintray {
+	user = project.hasProperty('bintrayUser') ? project.getProperty('bintrayUser') : System.getenv('bintray_user')
+	key = project.hasProperty('bintrayKey') ? project.getProperty('bintrayKey') : System.getenv('bintray_key')
+	publish = true
+	override = true
+	publications = ["${archivesBaseName}_mavenJava"]
+	pkg {
+		repo = project.bintrayRepo
+		name = archivesBaseName
+		user = bintray.user
+		userOrg = project.repoOwner
+		licenses = [project.codeLicense]
+		desc = project.description
+		websiteUrl = "https://github.com/${project.repoOwner}/${project.repoName}"
+		issueTrackerUrl = "https://github.com/${project.repoOwner}/${project.repoName}/issues"
+		vcsUrl = "https://github.com/${project.repoOwner}/${project.repoName}.git"
+		publicDownloadNumbers = true
+
+		githubRepo = "${project.repoOwner}/${project.repoName}"
+		version {
+			name = project.version
+			released = new Date()
+		}
+	}
+}
+
+rootProject.bintrayUpload.dependsOn(bintrayUpload)
+
+javadoc.enabled = false
+
+rootProject.licenseFormatAll.dependsOn(licenseFormat)
+
+rootProject.remapJar.dependsOn(remapJar)

--- a/buildSrc/src/main/groovy/patchwork-api.submodule-conventions.gradle
+++ b/buildSrc/src/main/groovy/patchwork-api.submodule-conventions.gradle
@@ -58,3 +58,10 @@ javadoc.enabled = false
 rootProject.licenseFormatAll.dependsOn(licenseFormat)
 
 rootProject.remapJar.dependsOn(remapJar)
+
+rootProject.dependencies {
+	afterEvaluate {
+		compile project(path: ":${project.name}", configuration: "dev")
+		include project(":${project.name}:")
+	}
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,8 @@ repoName=patchwork-api
 repoOwner=patchworkmc
 bintrayRepo=Patchwork-Maven
 codeLicense=LGPL-2.1
+
+
+baseVersion = 0.10.0
+mcVersion = 1.14.4
+yarnVersion = +build.16

--- a/patchwork-api-base/build.gradle
+++ b/patchwork-api-base/build.gradle
@@ -1,2 +1,6 @@
+plugins {
+	id 'patchwork-api.module-conventions'
+}
+
 archivesBaseName = "patchwork-api-base"
 version = getSubprojectVersion(project, "0.1.1")

--- a/patchwork-biomes/build.gradle
+++ b/patchwork-biomes/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-biomes"
 version = getSubprojectVersion(project, "0.3.1")
 

--- a/patchwork-capabilities/build.gradle
+++ b/patchwork-capabilities/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-capabilities"
 version = getSubprojectVersion(project, "0.5.0")
 

--- a/patchwork-data-generators/build.gradle
+++ b/patchwork-data-generators/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-data-generators"
 version = getSubprojectVersion(project, "0.3.1")
 

--- a/patchwork-dispatcher/build.gradle
+++ b/patchwork-dispatcher/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-dispatcher"
 version = getSubprojectVersion(project, "0.5.0")
 

--- a/patchwork-enum-hacks/build.gradle
+++ b/patchwork-enum-hacks/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-enum-hacks"
 version = getSubprojectVersion(project, "0.3.1")
 

--- a/patchwork-events-entity/build.gradle
+++ b/patchwork-events-entity/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-events-entity"
 version = getSubprojectVersion(project, "0.7.0")
 

--- a/patchwork-events-input/build.gradle
+++ b/patchwork-events-input/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-events-input"
 version = getSubprojectVersion(project, "0.3.1")
 

--- a/patchwork-events-lifecycle/build.gradle
+++ b/patchwork-events-lifecycle/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-events-lifecycle"
 version = getSubprojectVersion(project, "0.3.2")
 

--- a/patchwork-events-rendering/build.gradle
+++ b/patchwork-events-rendering/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-client-colors"
 version = getSubprojectVersion(project, "0.3.3")
 

--- a/patchwork-events-world/build.gradle
+++ b/patchwork-events-world/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-events-world"
 version = getSubprojectVersion(project, "0.5.0")
 

--- a/patchwork-extensions-bakedmodel/build.gradle
+++ b/patchwork-extensions-bakedmodel/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-extensions-bakedmodel"
 version = getSubprojectVersion(project, "0.1.0")
 

--- a/patchwork-extensions-block/build.gradle
+++ b/patchwork-extensions-block/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-extensions-block"
 version = getSubprojectVersion(project, "0.5.0")
 

--- a/patchwork-extensions-blockentity/build.gradle
+++ b/patchwork-extensions-blockentity/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-extensions-blockentity"
 version = getSubprojectVersion(project, "0.2.0")
 

--- a/patchwork-extensions-entity/build.gradle
+++ b/patchwork-extensions-entity/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-extensions-entity"
 version = getSubprojectVersion(project, "0.1.0")
 

--- a/patchwork-extensions-item/build.gradle
+++ b/patchwork-extensions-item/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-extensions-item"
 version = getSubprojectVersion(project, "0.4.1")
 

--- a/patchwork-extensions-shearing/build.gradle
+++ b/patchwork-extensions-shearing/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-extensions-shearing"
 version = getSubprojectVersion(project, "0.3.1")
 

--- a/patchwork-extensions/build.gradle
+++ b/patchwork-extensions/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-extensions"
 version = getSubprojectVersion(project, "0.3.1")
 

--- a/patchwork-fake-players/build.gradle
+++ b/patchwork-fake-players/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-fake-players"
 version = getSubprojectVersion(project, "0.1.1")
 

--- a/patchwork-fml/build.gradle
+++ b/patchwork-fml/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-fml"
 version = getSubprojectVersion(project, "0.5.0")
 

--- a/patchwork-god-classes/build.gradle
+++ b/patchwork-god-classes/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-god-classes"
 version = getSubprojectVersion(project, "0.4.0")
 

--- a/patchwork-gui/build.gradle
+++ b/patchwork-gui/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-gui"
 version = getSubprojectVersion(project, "0.3.1")
 

--- a/patchwork-items/build.gradle
+++ b/patchwork-items/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-items"
 version = getSubprojectVersion(project, "0.1.1")
 

--- a/patchwork-key-bindings/build.gradle
+++ b/patchwork-key-bindings/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-key-bindings"
 version = getSubprojectVersion(project, "0.2.1")
 

--- a/patchwork-level-generators/build.gradle
+++ b/patchwork-level-generators/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-level-generators"
 version = getSubprojectVersion(project, "0.3.1")
 

--- a/patchwork-loot/build.gradle
+++ b/patchwork-loot/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-loot"
 version = getSubprojectVersion(project, "0.3.1")
 

--- a/patchwork-model-loader/build.gradle
+++ b/patchwork-model-loader/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-model-loader"
 version = getSubprojectVersion(project, "0.2.3")
 

--- a/patchwork-networking-messages/build.gradle
+++ b/patchwork-networking-messages/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-networking-messages"
 version = getSubprojectVersion(project, "0.3.2")
 

--- a/patchwork-networking/build.gradle
+++ b/patchwork-networking/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-networking"
 version = getSubprojectVersion(project, "0.4.0")
 

--- a/patchwork-recipes/build.gradle
+++ b/patchwork-recipes/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-recipes"
 version = getSubprojectVersion(project, "0.3.1")
 

--- a/patchwork-registries/build.gradle
+++ b/patchwork-registries/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-registries"
 version = getSubprojectVersion(project, "0.4.1")
 

--- a/patchwork-resource/build.gradle
+++ b/patchwork-resource/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-resource"
 version = getSubprojectVersion(project, "0.2.1")
 

--- a/patchwork-tags/build.gradle
+++ b/patchwork-tags/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-tags"
 version = getSubprojectVersion(project, "0.1.1")
 

--- a/patchwork-tooltype/build.gradle
+++ b/patchwork-tooltype/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-tooltype"
 version = getSubprojectVersion(project, "0.3.1")
 

--- a/patchwork-vanilla-patches/build.gradle
+++ b/patchwork-vanilla-patches/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'patchwork-api.submodule-conventions'
+}
+
 archivesBaseName = "patchwork-vanilla-patches"
 version = getSubprojectVersion(project, "0.3.1")
 


### PR DESCRIPTION
This is accomplished by moving away from subprojects and allprojects closures to using precompiled script plugins to accomplish the same thing. We can now opt out of the things in subprojects/allprojects by simply not applying the relevant plugin.

loom shareCaches won't quite work (and thus running this build in parallel) until https://github.com/FabricMC/fabric-loom/pull/299 is merged and present in a release of fabric-loom.

(Motivated by wanting to create an annotation processor as a subproject, which is decidedly *not* a fabric mod.)