### PR TITLE
Completely stub all classes in god-classes

### DIFF
--- a/patchwork-api-base/src/main/java/net/patchworkmc/annotations/Stubbed.java
+++ b/patchwork-api-base/src/main/java/net/patchworkmc/annotations/Stubbed.java
@@ -1,0 +1,33 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.patchworkmc.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an element as having been manually stubbed.
+ */
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.CLASS)
+public @interface Stubbed {
+}

--- a/patchwork-god-classes/README.md
+++ b/patchwork-god-classes/README.md
@@ -1,12 +1,15 @@
 # patchwork-god-classes
 
-Implementation of ForgeHooks, ForgeHooksClient, ForgeEventFactory, and BasicEventHooks that dispatches to different patchwork modules.
+Implementation of ForgeHooks, ForgeHooksClient, ForgeEventFactory, ClientHooks, and BasicEventHooks that dispatches to different patchwork modules.
 
 ## Reasoning
 
 Forge uses these classes from inside their patches in order to keep the size of their patches down.
 Patchwork keeps its hooks seperated between modules, however, some mods also use these classes.
 Therefore, this module exists to dispatch calls to these classes to the disperate modules that actually implement the relevant methods.
+
+Don't depend on this module from other modules. If you feel the need to do so, something has gone wrong
+and implementation details should be moved into its proper module.
 
 ## TODO
  * Implement the methods on these classes that are actually already implemented in Patchwork.

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -19,34 +19,463 @@
 
 package net.minecraftforge.client;
 
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+
+import javax.annotation.Nonnull;
+
+import org.apache.commons.lang3.NotImplementedException;
 
 import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.color.item.ItemColors;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.TitleScreen;
+import net.minecraft.client.input.Input;
+import net.minecraft.client.render.BackgroundRenderer;
+import net.minecraft.client.render.BufferBuilder;
+import net.minecraft.client.render.Camera;
+import net.minecraft.client.render.GameRenderer;
+import net.minecraft.client.render.VertexFormat;
+import net.minecraft.client.render.VertexFormatElement;
+import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.render.entity.model.BipedEntityModel;
+import net.minecraft.client.render.item.ItemRenderer;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.BakedModelManager;
+import net.minecraft.client.render.model.BakedQuad;
+import net.minecraft.client.render.model.ModelLoader;
+import net.minecraft.client.render.model.ModelRotation;
+import net.minecraft.client.render.model.json.ModelTransformation;
+import net.minecraft.client.render.model.json.Transformation;
+import net.minecraft.client.sound.SoundInstance;
+import net.minecraft.client.sound.SoundSystem;
 import net.minecraft.client.texture.SpriteAtlasTexture;
+import net.minecraft.client.util.Window;
+import net.minecraft.client.util.math.Matrix4f;
+import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.RecipeManager;
+import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
 import net.minecraft.client.Mouse;
+import net.minecraft.util.Pair;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
 
 import net.patchworkmc.impl.event.input.InputEvents;
 import net.patchworkmc.impl.event.render.RenderEvents;
 import net.patchworkmc.impl.extensions.item.PatchworkArmorItemHandler;
+import net.patchworkmc.annotations.Stubbed;
 
-/*
- * Note: this class is intended for mod use only, to dispatch to the implementations kept in their own modules.
- * Do not keep implementation details here, methods should be thin wrappers around methods in other modules.
+/**
+ * A stubbed out copy of Forge's ForgeHooksClient, intended for use by Forge mods only.
+ * For methods that you are implementing, don't keep implementation details here.
+ * Elements should be thin wrappers around methods in other modueles.
  */
 public class ForgeHooksClient {
+	// static final ThreadLocal<BlockRenderLayer> renderLayer = new ThreadLocal<BlockRenderLayer>();
+
+	// private static final ResourceLocation ITEM_GLINT = new ResourceLocation("textures/misc/enchanted_item_glint.png");
+	// private static final Logger LOGGER = LogManager.getLogger();
+	// private static final Matrix4f flipX;
+	// private static final FloatBuffer matrixBuf = BufferUtils.createFloatBuffer(16);
+	// private static final LightGatheringTransformer lightGatherer = new LightGatheringTransformer();
+	public static String forgeStatusLine;
+	// static RenderBlocks VertexBufferRB;
+	// static int worldRenderPass;
+	// private static int skyX, skyZ;
+	// private static boolean skyInit;
+	// private static int skyRGBMultiplier;
+	// private static int slotMainHand = 0;
+
+	/**
+	 * Initialization of Forge Renderers.
+	 */
+	static {
+		//FluidRegistry.renderIdFluid = RenderingRegistry.getNextAvailableRenderId();
+		//RenderingRegistry.registerBlockHandler(RenderBlockFluid.instance);
+	}
+
+	//static {
+	//	flipX = new Matrix4f();
+	//	flipX.setIdentity();
+	//	flipX.m00 = -1;
+	//}
+
 	public static String getArmorTexture(Entity entity, ItemStack armor, String defaultTexture, EquipmentSlot slot, String type) {
 		return PatchworkArmorItemHandler.patchwork$getArmorTexture(entity, armor, defaultTexture, slot, type);
 	}
 
+	@Stubbed
+	public static boolean onDrawBlockHighlight(WorldRenderer context, Camera info, HitResult target, int subID, float partialTicks) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static void dispatchRenderLast(WorldRenderer context, float partialTicks) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean renderFirstPersonHand(WorldRenderer context, float partialTicks) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean renderSpecificFirstPersonHand(Hand hand, float partialTicks, float interpPitch, float swingProgress, float equipProgress, ItemStack stack) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	public static void onTextureStitchedPre(SpriteAtlasTexture map, Set<Identifier> resourceLocations) {
+		RenderEvents.onTextureStitchPre(map, resourceLocations);
+	}
+
+	public static void onTextureStitchedPost(SpriteAtlasTexture map) {
+		RenderEvents.onTextureStitchPost(map);
+	}
+
+	public static void onBlockColorsInit(BlockColors blockColors) {
+		RenderEvents.onBlockColorsInit(blockColors);
+	}
+
+	public static void onItemColorsInit(ItemColors itemColors, BlockColors blockColors) {
+		RenderEvents.onItemColorsInit(itemColors, blockColors);
+	}
+
+	/*
+	@Stubbed
+	public static void setRenderLayer(BlockRenderLayer layer) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+		//renderLayer.set(layer);
+	} */
+
 	public static <A extends BipedEntityModel<?>> A getArmorModel(LivingEntity livingEntity, ItemStack itemStack, EquipmentSlot slot, A defaultModel) {
 		return PatchworkArmorItemHandler.patchwork$getArmorModel(livingEntity, itemStack, slot, defaultModel);
+	}
+
+	// NOTE: this appears to be unused?
+	//This properly moves the domain, if provided, to the front of the string before concatenating
+	public static String fixDomain(String base, String complex) {
+		int idx = complex.indexOf(':');
+
+		if (idx == -1) {
+			return base + complex;
+		}
+
+		String name = complex.substring(idx + 1);
+
+		if (idx > 1) {
+			String domain = complex.substring(0, idx);
+			return domain + ':' + base + name;
+		} else {
+			return base + name;
+		}
+	}
+
+	/* TODO (Forge): mouse input
+	public static boolean postMouseEvent() {
+		return MinecraftForge.EVENT_BUS.post(new MouseEvent());
+	} */
+
+	@Stubbed
+	public static float getOffsetFOV(PlayerEntity entity, float fov) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static double getFOVModifier(GameRenderer renderer, Camera info, double renderPartialTicks, double fov) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static int getSkyBlendColour(World world, BlockPos center) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static void renderMainMenu(TitleScreen gui, TextRenderer font, int width, int height) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+		// status line var is set here
+	}
+
+	@Stubbed
+	public static SoundInstance playSound(SoundSystem manager, SoundInstance sound) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static int getWorldRenderPass() {
+		throw new NotImplementedException("ForgeHooksClient stub");
+		//return worldRenderPass;
+	}
+
+	@Stubbed
+	public static void drawScreen(Screen screen, int mouseX, int mouseY, float partialTicks) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static float getFogDensity(BackgroundRenderer fogRenderer, GameRenderer renderer, Camera info, float partial, float density) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static void onFogRender(BackgroundRenderer fogRenderer, GameRenderer renderer, Camera info, float partial, int mode, float distance) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	/*
+	@Stubbed
+	public static EntityViewRenderEvent.CameraSetup onCameraSetup(GameRenderer renderer, Camera info, float partial, float yaw, float pitch, float roll) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	} */
+
+	@Stubbed
+	public static void onModelBake(BakedModelManager modelManager, Map<Identifier, BakedModel> modelRegistry, ModelLoader modelLoader) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@SuppressWarnings("deprecation")
+	@Stubbed
+	public static Matrix4f getMatrix(Transformation transform) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	// moved and expanded from WorldVertexBufferUploader.draw
+
+	@Stubbed
+	public static BakedModel handleCameraTransforms(BakedModel model, ModelTransformation.Type cameraTransformType, boolean leftHandHackery) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static void multiplyCurrentGlMatrix(Matrix4f matrix) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static void preDraw(VertexFormatElement.Type attrType, VertexFormat format, int element, int stride, ByteBuffer buffer) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static void postDraw(VertexFormatElement.Type attrType, VertexFormat format, int element, int stride, ByteBuffer buffer) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static void transform(Vector3f vec, Matrix4f m) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static Matrix4f getMatrix(ModelRotation modelRotation) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static void putQuadColor(BufferBuilder renderer, BakedQuad quad, int color) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	/*
+	@Stubbed
+	public static Sprite[] getFluidSprites(ExtendedBlockView world, BlockPos pos, FluidState fluidStateIn) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	} */
+
+	@Stubbed
+	public static void gatherFluidTextures(Set<Identifier> textures) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static void renderLitItem(ItemRenderer ri, BakedModel model, int color, ItemStack stack) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	private static void drawSegment(ItemRenderer ri, int baseColor, ItemStack stack, List<BakedQuad> segment, int bl, int sl, boolean shade, boolean updateLighting, boolean updateShading) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	/**
+	 * internal, relies on fixed format of FaceBakery.
+	 */
+	@Stubbed
+	public static void fillNormal(int[] faceData, Direction facing) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	private static Vector3f getVertexPos(int[] data, int vertex) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	/*
+	@SuppressWarnings("deprecation")
+	@Stubbed
+	public static Optional<TRSRTransformation> applyTransform(Transformation transform, Optional<? extends IModelPart> part) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	} */
+
+	/*
+	@Stubbed
+	public static Optional<TRSRTransformation> applyTransform(ModelRotation rotation, Optional<? extends IModelPart> part) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	} */
+
+	/*
+	@Stubbed
+	public static Optional<TRSRTransformation> applyTransform(Matrix4f matrix, Optional<? extends IModelPart> part) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	} */
+
+	@Stubbed
+	public static void loadEntityShader(Entity entity, GameRenderer entityRenderer) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	/*
+	@Stubbed
+	public static BakedModel getDamageModel(BakedModel ibakedmodel, Sprite texture, BlockState state, ExtendedBlockView world, BlockPos pos, long randomPosition) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	} */
+
+	@Stubbed
+	public static boolean shouldCauseReequipAnimation(@Nonnull ItemStack from, @Nonnull ItemStack to, int slot) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	/*
+	@Stubbed
+	public static ModelElementTexture applyUVLock(ModelElementTexture blockFaceUV, Direction originalSide, ITransformation rotation) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	} */
+
+	/*
+	@Stubbed
+	public static RenderGameOverlayEvent.BossInfo bossBarRenderPre(Window res, ClientBossBar bossInfo, int x, int y, int increment) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	} */
+
+	@Stubbed
+	public static void bossBarRenderPost(Window res) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	/*
+	@Stubbed
+	public static ScreenshotEvent onScreenshot(NativeImage image, File screenshotFile) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	} */
+
+	@SuppressWarnings("deprecation")
+	@Stubbed
+	public static Pair<? extends BakedModel, Matrix4f> handlePerspective(BakedModel model, ModelTransformation.Type type) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static void onInputUpdate(PlayerEntity player, Input movementInput) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	/*
+	@Stubbed
+	public static void refreshResources(MinecraftClient mc, VanillaResourceType... types) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	} */
+
+	@Stubbed
+	public static boolean onGuiMouseClickedPre(Screen guiScreen, double mouseX, double mouseY, int button) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean onGuiMouseClickedPost(Screen guiScreen, double mouseX, double mouseY, int button) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean onGuiMouseReleasedPre(Screen guiScreen, double mouseX, double mouseY, int button) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean onGuiMouseReleasedPost(Screen guiScreen, double mouseX, double mouseY, int button) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean onGuiMouseDragPre(Screen guiScreen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean onGuiMouseDragPost(Screen guiScreen, double mouseX, double mouseY, int mouseButton, double dragX, double dragY) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean onGuiMouseScrollPre(Mouse mouseHelper, Screen guiScreen, double scrollDelta) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean onGuiMouseScrollPost(Mouse mouseHelper, Screen guiScreen, double scrollDelta) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean onGuiKeyPressedPre(Screen guiScreen, int keyCode, int scanCode, int modifiers) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean onGuiKeyPressedPost(Screen guiScreen, int keyCode, int scanCode, int modifiers) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean onGuiKeyReleasedPre(Screen guiScreen, int keyCode, int scanCode, int modifiers) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean onGuiKeyReleasedPost(Screen guiScreen, int keyCode, int scanCode, int modifiers) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean onGuiCharTypedPre(Screen guiScreen, char codePoint, int modifiers) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static boolean onGuiCharTypedPost(Screen guiScreen, char codePoint, int modifiers) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	@Stubbed
+	public static void onRecipesUpdated(RecipeManager mgr) {
+		throw new NotImplementedException("ForgeHooksClient stub");
+	}
+
+	// Resets cached thread fields in ThreadNameCachingStrategy and ReusableLogEventFactory to be repopulated during their next access.
+	// This serves a workaround for no built-in method of triggering this type of refresh as brought up by LOG4J2-2178.
+	@Stubbed
+	public static void invalidateLog4jThreadCache() {
+		throw new NotImplementedException("ForgeHooksClient stub");
 	}
 
 	public static void fireMouseInput(int button, int action, int mods) {
@@ -65,19 +494,52 @@ public class ForgeHooksClient {
 		return InputEvents.onRawMouseClicked(button, action, mods);
 	}
 
-	public static void onBlockColorsInit(BlockColors blockColors) {
-		RenderEvents.onBlockColorsInit(blockColors);
-	}
-
-	public static void onItemColorsInit(ItemColors itemColors, BlockColors blockColors) {
-		RenderEvents.onItemColorsInit(itemColors, blockColors);
-	}
-
-	public static void onTextureStitchedPre(SpriteAtlasTexture map, Set<Identifier> resourceLocations) {
-		RenderEvents.onTextureStitchPre(map, resourceLocations);
-	}
-
-	public static void onTextureStitchedPost(SpriteAtlasTexture map) {
-		RenderEvents.onTextureStitchPost(map);
-	}
+	//private static class LightGatheringTransformer extends QuadGatheringTransformer {
+	//
+	//	private static final VertexFormat FORMAT = new VertexFormat().add(VertexFormats.UV_ELEMENT).add(VertexFormats.LMAP_ELEMENT);
+	//
+	//	int blockLight, skyLight;
+	//
+	//	{
+	//		setVertexFormat(FORMAT);
+	//	}
+	//
+	//	boolean hasLighting() {
+	//		return dataLength[1] >= 2;
+	//	}
+	//
+	//	@Override
+	//	protected void processQuad() {
+	//		// Reset light data
+	//		blockLight = 0;
+	//		skyLight = 0;
+	//		// Compute average light for all 4 vertices
+	//		for (int i = 0; i < 4; i++) {
+	//			blockLight += (int) ((quadData[1][i][0] * 0xFFFF) / 0x20);
+	//			skyLight += (int) ((quadData[1][i][1] * 0xFFFF) / 0x20);
+	//		}
+	//		// Values must be multiplied by 16, divided by 4 for average => x4
+	//		blockLight *= 4;
+	//		skyLight *= 4;
+	//	}
+	//
+	//	// Dummy overrides
+	//
+	//	@Override
+	//	public void setQuadTint(int tint) {
+	//	}
+	//
+	//	@Override
+	//	public void setQuadOrientation(Direction orientation) {
+	//	}
+	//
+	//	@Override
+	//	public void setApplyDiffuseLighting(boolean diffuse) {
+	//	}
+	//
+	//	@Override
+	//	public void setTexture(Sprite texture) {
+	//	}
+	//}
 }
+

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -79,7 +79,8 @@ import net.patchworkmc.annotations.Stubbed;
 /**
  * A stubbed out copy of Forge's ForgeHooksClient, intended for use by Forge mods only.
  * For methods that you are implementing, don't keep implementation details here.
- * Elements should be thin wrappers around methods in other modueles.
+ * Elements should be thin wrappers around methods in other modules.
+ * Do not depend on this class in other modules.
  */
 public class ForgeHooksClient {
 	// static final ThreadLocal<BlockRenderLayer> renderLayer = new ThreadLocal<BlockRenderLayer>();

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -72,9 +72,11 @@ import net.patchworkmc.impl.extensions.block.BlockHarvestManager;
 import net.patchworkmc.impl.loot.LootHooks;
 import net.patchworkmc.annotations.Stubbed;
 
-/*
- * Note: this class is intended for mod use only, to dispatch to the implementations kept in their own modules.
- * Do not keep implementation details here, methods should be thin wrappers around methods in other modules.
+/**
+ * A stubbed out copy of Forge's ForgeHooks, intended for use by Forge mods only.
+ * For methods that you are implementing, don't keep implementation details here.
+ * Elements should be thin wrappers around methods in other modules.
+ * Do not depend on this class in other modules.
  */
 public class ForgeHooks {
 	//static final Pattern URL_PATTERN = Pattern.compile(

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -20,15 +20,33 @@
 package net.minecraftforge.common;
 
 import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Function;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.eventbus.api.Event;
+import org.apache.commons.lang3.NotImplementedException;
 
+import net.minecraft.advancement.Advancement;
 import net.minecraft.block.BlockState;
+import net.minecraft.container.AnvilContainer;
+import net.minecraft.entity.data.TrackedDataHandler;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemUsageContext;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.tag.Tag;
+import net.minecraft.text.Text;
+import net.minecraft.util.Int2ObjectBiMap;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.Difficulty;
 import net.minecraft.world.dimension.DimensionType;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.ItemEntity;
@@ -52,25 +70,74 @@ import net.minecraft.world.World;
 import net.patchworkmc.impl.event.entity.EntityEvents;
 import net.patchworkmc.impl.extensions.block.BlockHarvestManager;
 import net.patchworkmc.impl.loot.LootHooks;
+import net.patchworkmc.annotations.Stubbed;
 
 /*
  * Note: this class is intended for mod use only, to dispatch to the implementations kept in their own modules.
  * Do not keep implementation details here, methods should be thin wrappers around methods in other modules.
  */
 public class ForgeHooks {
-	public static int canEntitySpawn(MobEntity entity, IWorld world, double x, double y, double z, MobSpawnerLogic spawner, SpawnType spawnReason) {
-		Event.Result res = ForgeEventFactory.canEntitySpawn(entity, world, x, y, z, null, spawnReason);
-		return res == Event.Result.DEFAULT ? 0 : res == Event.Result.DENY ? -1 : 1;
+	//static final Pattern URL_PATTERN = Pattern.compile(
+	//	//         schema                          ipv4            OR        namespace                 port     path         ends
+	//	//   |-----------------|        |-------------------------|  |-------------------------|    |---------| |--|   |---------------|
+	//	"((?:[a-z0-9]{2,}:\\/\\/)?(?:(?:[0-9]{1,3}\\.){3}[0-9]{1,3}|(?:[-\\w_]{1,}\\.[a-z]{2,}?))(?::[0-9]{1,5})?.*?(?=[!\"\u00A7 \n]|$))",
+	//	Pattern.CASE_INSENSITIVE);
+	//private static final Logger LOGGER = LogManager.getLogger();
+	//private static final Marker FORGEHOOKS = MarkerManager.getMarker("FORGEHOOKS");
+	//private static final DummyBlockReader DUMMY_WORLD = new DummyBlockReader();
+	//private static final Map<TrackedDataHandler<?>, DataSerializerEntry> serializerEntries = GameData.getSerializerMap();
+	//private static final Map<IRegistryDelegate<Item>, Integer> VANILLA_BURNS = new HashMap<>();
+	//private static boolean toolInit = false;
+	//private static ThreadLocal<PlayerEntity> craftingPlayer = new ThreadLocal<PlayerEntity>();
+	@SuppressWarnings({ "unused" })
+	private static ThreadLocal<?> lootContext = LootHooks.lootContext;
+	//private static TriConsumer<Block, ToolType, Integer> blockToolSetter;
+
+	@Stubbed
+	public static boolean canContinueUsing(@Nonnull ItemStack from, @Nonnull ItemStack to) {
+		throw new NotImplementedException("ForgeHooks stub");
 	}
 
-	// TODO: onInteractEntityAt
-
-	public static ActionResult onInteractEntity(PlayerEntity player, Entity entity, Hand hand) {
-		return EntityEvents.onInteractEntity(player, entity, hand);
+	@Stubbed
+	public static boolean canHarvestBlock(@Nonnull BlockState state, @Nonnull PlayerEntity player, @Nonnull BlockView world, @Nonnull BlockPos pos) {
+		throw new NotImplementedException("ForgeHooks stub");
 	}
 
-	public static boolean onLivingDeath(LivingEntity entity, DamageSource src) {
-		return EntityEvents.onLivingDeath(entity, src);
+	/*
+	@Stubbed
+	public static boolean canToolHarvestBlock(ViewableWorld world, BlockPos pos, @Nonnull ItemStack stack) {
+		throw new NotImplementedException("ForgeHooks stub");
+	} */
+
+	/*
+	@Stubbed
+	public static boolean isToolEffective(ViewableWorld world, BlockPos pos, @Nonnull ItemStack stack) {
+		throw new NotImplementedException("ForgeHooks stub");
+	} */
+
+	@Stubbed
+	static void initTools() {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	/**
+	 * Called when a player uses 'pick block', calls new Entity and Block hooks.
+	 */
+	@Stubbed
+	public static boolean onPickBlock(HitResult target, PlayerEntity player, World world) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	public static void onDifficultyChange(Difficulty difficulty, Difficulty oldDifficulty) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	//Optifine Helper Functions u.u, these are here specifically for Optifine
+	//Note: When using Optifine, these methods are invoked using reflection, which
+	//incurs a major performance penalty.
+	public static void onLivingSetAttackTarget(LivingEntity entity, LivingEntity target) {
+		EntityEvents.onLivingSetAttackTarget(entity, target);
 	}
 
 	public static boolean onLivingUpdate(LivingEntity entity) {
@@ -86,13 +153,26 @@ public class ForgeHooks {
 		return !EntityEvents.onLivingAttack(entity, src, amount);
 	}
 
-	// optifine wants this? O.o
-	public static void onLivingSetAttackTarget(LivingEntity entity, LivingEntity target) {
-		EntityEvents.onLivingSetAttackTarget(entity, target);
-	}
+	/*
+	@Stubbed
+	public static LivingKnockBackEvent onLivingKnockBack(LivingEntity target, Entity attacker, float strength, double ratioX, double ratioZ) {
+		throw new NotImplementedException("ForgeHooks stub");
+	} */
 
 	public static float onLivingHurt(LivingEntity entity, DamageSource src, float amount) {
 		return EntityEvents.onLivingHurt(entity, src, amount);
+	}
+
+	public static float onLivingDamage(LivingEntity entity, DamageSource src, float amount) {
+		return EntityEvents.onLivingDamage(entity, src, amount);
+	}
+
+	public static boolean onLivingDeath(LivingEntity entity, DamageSource src) {
+		return EntityEvents.onLivingDeath(entity, src);
+	}
+
+	public static boolean onLivingDrops(LivingEntity entity, DamageSource source, Collection<ItemEntity> drops, int lootingLevel, boolean recentlyHit) {
+		return EntityEvents.onLivingDrops(entity, source, drops, lootingLevel, recentlyHit);
 	}
 
 	@Nullable
@@ -100,12 +180,84 @@ public class ForgeHooks {
 		return EntityEvents.onLivingFall(entity, distance, damageMultiplier);
 	}
 
-	public static float onLivingDamage(LivingEntity entity, DamageSource src, float amount) {
-		return EntityEvents.onLivingDamage(entity, src, amount);
+	@Stubbed
+	public static int getLootingLevel(Entity target, @Nullable Entity killer, DamageSource cause) {
+		throw new NotImplementedException("ForgeHooks stub");
 	}
 
-	public static boolean onLivingDrops(LivingEntity entity, DamageSource source, Collection<ItemEntity> drops, int lootingLevel, boolean recentlyHit) {
-		return EntityEvents.onLivingDrops(entity, source, drops, lootingLevel, recentlyHit);
+	@Stubbed
+	public static int getLootingLevel(LivingEntity target, DamageSource cause, int level) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	public static double getPlayerVisibilityDistance(PlayerEntity player, double xzDistance, double maxXZDistance) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	public static boolean isLivingOnLadder(@Nonnull BlockState state, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull LivingEntity entity) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	public static void onLivingJump(LivingEntity entity) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	@Nullable
+	public static ItemEntity onPlayerTossEvent(@Nonnull PlayerEntity player, @Nonnull ItemStack item, boolean includeName) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	@Nullable
+	public static Text onServerChatEvent(ServerPlayNetworkHandler net, String raw, Text comp) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	public static Text newChatWithLinks(String string) {
+		return newChatWithLinks(string, true);
+	}
+
+	@Stubbed
+	public static Text newChatWithLinks(String string, boolean allowMissingHeader) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	public static int onBlockBreakEvent(World world, GameMode gameType, ServerPlayerEntity entityPlayer, BlockPos pos) {
+		return BlockHarvestManager.onBlockBreakEvent(world, gameType, entityPlayer, pos);
+	}
+
+	@Stubbed
+	public static ActionResult onPlaceItemIntoWorld(@Nonnull ItemUsageContext context) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	public static boolean onAnvilChange(AnvilContainer container, @Nonnull ItemStack left, @Nonnull ItemStack right, Inventory outputSlot, String name, int baseCost) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	public static float onAnvilRepair(PlayerEntity player, @Nonnull ItemStack output, @Nonnull ItemStack left, @Nonnull ItemStack right) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	public static PlayerEntity getCraftingPlayer() {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	public static void setCraftingPlayer(PlayerEntity player) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	@Nonnull
+	public static ItemStack getContainerItem(@Nonnull ItemStack stack) {
+		throw new NotImplementedException("ForgeHooks stub");
 	}
 
 	public static boolean onPlayerAttackTarget(PlayerEntity player, Entity target) {
@@ -116,12 +268,171 @@ public class ForgeHooks {
 		return EntityEvents.onTravelToDimension(entity, dimensionType);
 	}
 
-	public static int onBlockBreakEvent(World world, GameMode gameType, ServerPlayerEntity entityPlayer, BlockPos pos) {
-		return BlockHarvestManager.onBlockBreakEvent(world, gameType, entityPlayer, pos);
+	// TODO: I left this here for now because it's a thin wrapper around the onInteractEntityAt below
+	public static ActionResult onInteractEntityAt(PlayerEntity player, Entity entity, HitResult ray, Hand hand) {
+		Vec3d vec3d = new Vec3d(ray.getPos().x - entity.x, ray.getPos().y - entity.y, ray.getPos().z - entity.z);
+		return onInteractEntityAt(player, entity, vec3d, hand);
 	}
 
-	@SuppressWarnings({ "rawtypes", "unused" })
-	private static ThreadLocal<?> lootContext = LootHooks.lootContext;
+	@Stubbed
+	public static ActionResult onInteractEntityAt(PlayerEntity player, Entity entity, Vec3d vec3d, Hand hand) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	public static ActionResult onInteractEntity(PlayerEntity player, Entity entity, Hand hand) {
+		return EntityEvents.onInteractEntity(player, entity, hand);
+	}
+
+	@Stubbed
+	public static ActionResult onItemRightClick(PlayerEntity player, Hand hand) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	/*
+	@Stubbed
+	public static PlayerInteractEvent.LeftClickBlock onLeftClickBlock(PlayerEntity player, BlockPos pos, Direction face) {
+		throw new NotImplementedException("ForgeHooks stub");
+	} */
+
+	/*
+	@Stubbed
+	public static PlayerInteractEvent.RightClickBlock onRightClickBlock(PlayerEntity player, Hand hand, BlockPos pos, Direction face) {
+		throw new NotImplementedException("ForgeHooks stub");
+	} */
+
+	@Stubbed
+	public static void onEmptyClick(PlayerEntity player, Hand hand) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	public static void onEmptyLeftClick(PlayerEntity player) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	//private static LootTableContext getLootTableContext() {
+	//	LootTableContext ctx = lootContext.get().peek();
+	//
+	//	if (ctx == null) {
+	//		throw new JsonParseException("Invalid call stack, could not grab json context!"); // Should I throw this? Do we care about custom deserializers outside the manager?
+	//	}
+	//
+	//	return ctx;
+	//}
+
+	@Nullable
+	public static LootTable loadLootTable(Gson gson, Identifier name, JsonObject data, boolean custom, LootManager lootTableManager) {
+		return LootHooks.loadLootTable(gson, name, data, custom, lootTableManager);
+	}
+
+	/*
+	@Stubbed
+	public static FluidAttributes createVanillaFluidAttributes(Fluid fluid) {
+		throw new NotImplementedException("ForgeHooks stub");
+	} */
+
+	public static String readPoolName(JsonObject json) {
+		return LootHooks.readPoolName(json);
+	}
+
+	@Stubbed
+	public static String readLootEntryName(JsonObject json, String type) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	public static boolean onCropsGrowPre(World worldIn, BlockPos pos, BlockState state, boolean def) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	public static void onCropsGrowPost(World worldIn, BlockPos pos, BlockState state) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	/*
+	@Stubbed
+	@Nullable
+	public static CriticalHitEvent getCriticalHit(PlayerEntity player, Entity target, boolean vanillaCritical, float damageModifier) {
+		throw new NotImplementedException("ForgeHooks stub");
+	} */
+
+	@Stubbed
+	public static void onAdvancement(ServerPlayerEntity player, Advancement advancement) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	/**
+	 * Used as the default implementation of {@link Item#getCreatorModId}. Call that method instead.
+	 */
+	@Stubbed
+	@Nullable
+	public static String getDefaultCreatorModId(@Nonnull ItemStack itemStack) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	public static boolean onFarmlandTrample(World world, BlockPos pos, BlockState state, float fallDistance, Entity entity) {
+		return BlockHarvestManager.onFarmlandTrample(world, pos, state, fallDistance, entity);
+	}
+
+	//Internal use only Modders, this is specifically hidden from you, as you shouldn't be editing other people's blocks.
+	//public static void setBlockToolSetter(TriConsumer<Block, ToolType, Integer> setter) {
+	//	blockToolSetter = setter;
+	//}
+
+	@Stubbed
+	@SuppressWarnings("unchecked")
+	private static <T, E> T getPrivateValue(Class<? super E> classToAccess, @Nullable E instance, int fieldIndex) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	public static int onNoteChange(World world, BlockPos pos, BlockState state, int old, int _new) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	// yes this is a direct copy of a forge method for once
+	public static int canEntitySpawn(MobEntity entity, IWorld world, double x, double y, double z, MobSpawnerLogic spawner, SpawnType spawnReason) {
+		Event.Result res = ForgeEventFactory.canEntitySpawn(entity, world, x, y, z, null, spawnReason);
+		return res == Event.Result.DEFAULT ? 0 : res == Event.Result.DENY ? -1 : 1;
+	}
+
+	@Stubbed
+	public static <T> void deserializeTagAdditions(Tag.Builder<T> builder, Function<Identifier, Optional<T>> valueGetter, JsonObject json) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	@Nullable
+	public static TrackedDataHandler<?> getSerializer(int id, Int2ObjectBiMap<TrackedDataHandler<?>> vanilla) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	public static int getSerializerId(TrackedDataHandler<?> serializer, Int2ObjectBiMap<TrackedDataHandler<?>> vanilla) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	//private static final ForgeRegistry<DataSerializerEntry> serializerRegistry = (ForgeRegistry<DataSerializerEntry>) ForgeRegistries.DATA_SERIALIZERS;
+	// Do not reimplement this ^ it introduces a chicken-egg scenario by classloading registries during bootstrap
+
+	@Stubbed
+	public static boolean canEntityDestroy(World world, BlockPos pos, LivingEntity entity) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	/**
+	 * Gets the burn time of this itemstack.
+	 */
+	@Stubbed
+	public static int getBurnTime(ItemStack stack) {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
+
+	@Stubbed
+	public static synchronized void updateBurns() {
+		throw new NotImplementedException("ForgeHooks stub");
+	}
 
 	// Need to have the class here to make some mod hacks work
 	public static class LootTableContext extends LootHooks.LootTableContext {
@@ -130,16 +441,46 @@ public class ForgeHooks {
 		}
 	}
 
-	@Nullable
-	public static LootTable loadLootTable(Gson gson, Identifier name, JsonObject data, boolean custom, LootManager lootTableManager) {
-		return LootHooks.loadLootTable(gson, name, data, custom, lootTableManager);
-	}
+	//private static class DummyBlockReader implements BlockView {
+	//
+	//	@Override
+	//	public BlockEntity getBlockEntity(BlockPos pos) {
+	//		return null;
+	//	}
+	//
+	//	@Override
+	//	public BlockState getBlockState(BlockPos pos) {
+	//		return Blocks.AIR.getDefaultState();
+	//	}
+	//
+	//	@Override
+	//	public FluidState getFluidState(BlockPos pos) {
+	//		return Fluids.EMPTY.getDefaultState();
+	//	}
+	//
+	//}
 
-	public static String readPoolName(JsonObject json) {
-		return LootHooks.readPoolName(json);
-	}
-
-	public static boolean onFarmlandTrample(World world, BlockPos pos, BlockState state, float fallDistance, Entity entity) {
-		return BlockHarvestManager.onFarmlandTrample(world, pos, state, fallDistance, entity);
-	}
+	//private static class OptionalTagEntry<T> extends Tag.TagEntry<T> {
+	//	private Tag<T> resolvedTag = null;
+	//
+	//	OptionalTagEntry(Identifier referent) {
+	//		super(referent);
+	//	}
+	//
+	//	@Override
+	//	public boolean applyTagGetter(@Nonnull Function<Identifier, Tag<T>> resolver) {
+	//		if (this.resolvedTag == null) {
+	//			this.resolvedTag = resolver.apply(this.getId());
+	//		}
+	//		return true; // never fail if resolver returns null
+	//	}
+	//
+	//	@Override
+	//	public void build(@Nonnull Collection<T> items) {
+	//		if (this.resolvedTag != null) {
+	//			items.addAll(this.resolvedTag.values());
+	//		}
+	//	}
+	//}
 }
+

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -19,14 +19,22 @@
 
 package net.minecraftforge.event;
 
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import net.minecraftforge.common.capabilities.CapabilityDispatcher;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.eventbus.api.Event;
+import org.apache.commons.lang3.NotImplementedException;
 
+import net.minecraft.entity.EntityCategory;
+import net.minecraft.entity.LightningEntity;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.SpawnType;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.passive.AnimalEntity;
@@ -36,17 +44,31 @@ import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.projectile.ExplosiveProjectileEntity;
 import net.minecraft.entity.projectile.ProjectileEntity;
 import net.minecraft.entity.thrown.ThrownEntity;
+import net.minecraft.item.ItemUsageContext;
 import net.minecraft.loot.LootManager;
 import net.minecraft.loot.LootTable;
+import net.minecraft.network.MessageType;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
+import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.MobSpawnerLogic;
+import net.minecraft.world.PlayerSaveHandler;
 import net.minecraft.world.World;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.DefaultedList;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.explosion.Explosion;
+import net.minecraft.world.level.LevelInfo;
 
 import net.patchworkmc.impl.capability.CapabilityEvents;
 import net.patchworkmc.impl.event.entity.EntityEvents;
@@ -54,20 +76,44 @@ import net.patchworkmc.impl.event.entity.PlayerEvents;
 import net.patchworkmc.impl.event.loot.LootEvents;
 import net.patchworkmc.impl.event.world.WorldEvents;
 import net.patchworkmc.impl.extensions.block.BlockHarvestManager;
+import net.patchworkmc.annotations.Stubbed;
 
 /*
  * Note: this class is intended for mod use only, to dispatch to the implementations kept in their own modules.
  * Do not keep implementation details here, methods should be thin wrappers around methods in other modules.
  */
 public class ForgeEventFactory {
-	@Nullable
-	public static <T> CapabilityDispatcher gatherCapabilities(Class<? extends T> type, T provider) {
-		return gatherCapabilities(type, provider, null);
+	/*
+	@Stubbed
+	public static boolean onMultiBlockPlace(@Nullable Entity entity, List<BlockSnapshot> blockSnapshots, Direction direction) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	} */
+
+	/*
+	@Stubbed
+	public static boolean onBlockPlace(@Nullable Entity entity, @Nonnull BlockSnapshot blockSnapshot, @Nonnull Direction direction) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	} */
+
+	/*
+	@Stubbed
+	public static NeighborNotifyEvent onNeighborNotify(World world, BlockPos pos, BlockState state, EnumSet<Direction> notifiedSides, boolean forceRedstoneUpdate) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	} */
+
+	@Stubbed
+	public static boolean doPlayerHarvestCheck(PlayerEntity player, BlockState state, boolean success) {
+		throw new NotImplementedException("ForgeEventFactory stub");
 	}
 
-	@Nullable
-	public static <T> CapabilityDispatcher gatherCapabilities(Class<? extends T> type, T provider, @Nullable ICapabilityProvider parent) {
-		return CapabilityEvents.gatherCapabilities(type, provider, parent);
+	@Stubbed
+	public static float getBreakSpeed(PlayerEntity player, BlockState state, float original, BlockPos pos) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static void onPlayerDestroyItem(PlayerEntity player, @Nonnull ItemStack stack, @Nullable Hand hand) {
+		throw new NotImplementedException("ForgeEventFactory stub");
 	}
 
 	public static Event.Result canEntitySpawn(MobEntity entity, IWorld world, double x, double y, double z, MobSpawnerLogic spawner, SpawnType spawnReason) {
@@ -78,20 +124,39 @@ public class ForgeEventFactory {
 		return EntityEvents.canEntitySpawnFromSpawner(entity, world, x, y, z, spawner);
 	}
 
-	public static void onPlayerFall(PlayerEntity player, float distance, float multiplier) {
-		EntityEvents.onFlyablePlayerFall(player, distance, multiplier);
-	}
-
 	public static boolean doSpecialSpawn(MobEntity entity, World world, float x, float y, float z, MobSpawnerLogic spawner, SpawnType spawnReason) {
 		return EntityEvents.doSpecialSpawn(entity, world, x, y, z, spawner, spawnReason);
 	}
 
-	public static LootTable loadLootTable(Identifier name, LootTable table, LootManager lootTableManager) {
-		return LootEvents.loadLootTable(name, table, lootTableManager);
+	@Stubbed
+	public static Event.Result canEntityDespawn(MobEntity entity) {
+		throw new NotImplementedException("ForgeEventFactory stub");
 	}
 
-	public static boolean saplingGrowTree(IWorld world, Random rand, BlockPos pos) {
-		return WorldEvents.onSaplingGrowTree(world, rand, pos);
+	@Stubbed
+	public static int getItemBurnTime(@Nonnull ItemStack itemStack, int burnTime) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static int getExperienceDrop(LivingEntity entity, PlayerEntity attackingPlayer, int originalExperience) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	@Nullable
+	public static List<Biome.SpawnEntry> getPotentialSpawns(IWorld world, EntityCategory type, BlockPos pos, List<Biome.SpawnEntry> oldList) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static int getMaxSpawnPackSize(MobEntity entity) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static String getPlayerDisplayName(PlayerEntity player, String username) {
+		throw new NotImplementedException("ForgeEventFactory stub");
 	}
 
 	// Forge might remove BlockEvent.HarvestDropsEvent, which is replaced by the new loot modifier.
@@ -100,8 +165,240 @@ public class ForgeEventFactory {
 		return BlockHarvestManager.fireBlockHarvesting(drops, world, pos, state, fortune, dropChance, silkTouch, player);
 	}
 
+	@Stubbed
+	public static BlockState fireFluidPlaceBlockEvent(IWorld world, BlockPos pos, BlockPos liquidPos, BlockState state) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	/*
+	@Stubbed
+	public static ItemTooltipEvent onItemTooltip(ItemStack itemStack, @Nullable PlayerEntity entityPlayer, List<Text> list, TooltipContext flags) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	} */
+
+	/*
+	@Stubbed
+	public static SummonAidEvent fireZombieSummonAid(ZombieEntity zombie, World world, int x, int y, int z, LivingEntity attacker, double summonChance) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	} */
+
+	@Stubbed
+	public static boolean onEntityStruckByLightning(Entity entity, LightningEntity bolt) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static int onItemUseStart(LivingEntity entity, ItemStack item, int duration) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static int onItemUseTick(LivingEntity entity, ItemStack item, int duration) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static boolean onUseItemStop(LivingEntity entity, ItemStack item, int duration) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static ItemStack onItemUseFinish(LivingEntity entity, ItemStack item, int duration, ItemStack result) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static void onStartEntityTracking(Entity entity, PlayerEntity player) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static void onStopEntityTracking(Entity entity, PlayerEntity player) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static void firePlayerLoadingEvent(PlayerEntity player, File playerDirectory, String uuidString) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static void firePlayerSavingEvent(PlayerEntity player, File playerDirectory, String uuidString) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static void firePlayerLoadingEvent(PlayerEntity player, PlayerSaveHandler playerFileData, String uuidString) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	@Nullable
+	public static Text onClientChat(MessageType type, Text message) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	@Nonnull
+	public static String onClientSendMessage(String message) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static int onHoeUse(ItemUsageContext context) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static int onApplyBonemeal(@Nonnull PlayerEntity player, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull BlockState state, @Nonnull ItemStack stack) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	@Nullable
+	public static TypedActionResult<ItemStack> onBucketUse(@Nonnull PlayerEntity player, @Nonnull World world, @Nonnull ItemStack stack, @Nullable HitResult target) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static boolean canEntityUpdate(Entity entity) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	/*
+	@Stubbed
+	public static PlaySoundAtEntityEvent onPlaySoundAtEntity(Entity entity, SoundEvent name, SoundCategory category, float volume, float pitch) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	} */
+
+	@Stubbed
+	public static int onItemExpire(ItemEntity entity, @Nonnull ItemStack item) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	public static int onItemPickup(ItemEntity item, PlayerEntity player) {
+		return PlayerEvents.onItemPickup(player, item);
+	}
+
+	@Stubbed
+	public static boolean canMountEntity(Entity entityMounting, Entity entityBeingMounted, boolean isMounting) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
 	public static boolean onAnimalTame(AnimalEntity animal, PlayerEntity tamer) {
 		return EntityEvents.onAnimalTame(animal, tamer);
+	}
+
+	@Stubbed
+	public static PlayerEntity.SleepFailureReason onPlayerSleepInBed(PlayerEntity player, Optional<BlockPos> pos) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static void onPlayerWakeup(PlayerEntity player, boolean wakeImmediately, boolean updateWorldFlag, boolean setSpawn) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	public static void onPlayerFall(PlayerEntity player, float distance, float multiplier) {
+		EntityEvents.onFlyablePlayerFall(player, distance, multiplier);
+	}
+
+	@Stubbed
+	public static boolean onPlayerSpawnSet(PlayerEntity player, BlockPos pos, boolean forced) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static void onPlayerClone(PlayerEntity player, PlayerEntity oldPlayer, boolean wasDeath) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static boolean onExplosionStart(World world, Explosion explosion) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static void onExplosionDetonate(World world, Explosion explosion, List<Entity> list, double diameter) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static boolean onCreateWorldSpawn(World world, LevelInfo settings) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static float onLivingHeal(LivingEntity entity, float amount) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static boolean onPotionAttemptBrew(DefaultedList<ItemStack> stacks) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static void onPotionBrewed(DefaultedList<ItemStack> brewingItemStacks) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static void onPlayerBrewedPotion(PlayerEntity player, ItemStack stack) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static boolean renderFireOverlay(PlayerEntity player, float renderPartialTicks) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static boolean renderWaterOverlay(PlayerEntity player, float renderPartialTicks) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	/*
+	@Stubbed
+	public static boolean renderBlockOverlay(PlayerEntity player, float renderPartialTicks, OverlayType type, BlockState block, BlockPos pos) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	} */
+
+	@Nullable
+	public static <T> CapabilityDispatcher gatherCapabilities(Class<? extends T> type, T provider) {
+		return gatherCapabilities(type, provider, null);
+	}
+
+	@Nullable
+	public static <T> CapabilityDispatcher gatherCapabilities(Class<? extends T> type, T provider, @Nullable ICapabilityProvider parent) {
+		return CapabilityEvents.gatherCapabilities(type, provider, parent);
+	}
+
+	/*
+	@Stubbed
+	@Nullable
+	private static CapabilityDispatcher gatherCapabilities(AttachCapabilitiesEvent<?> event, @Nullable ICapabilityProvider parent) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	} */
+
+	@Stubbed
+	public static boolean fireSleepingLocationCheck(LivingEntity player, BlockPos sleepingLocation) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static boolean fireSleepingTimeCheck(PlayerEntity player, Optional<BlockPos> sleepingLocation) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static TypedActionResult<ItemStack> onArrowNock(ItemStack item, World world, PlayerEntity player, Hand hand, boolean hasAmmo) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static int onArrowLoose(ItemStack stack, World world, PlayerEntity player, int charge, boolean hasAmmo) {
+		throw new NotImplementedException("ForgeEventFactory stub");
 	}
 
 	public static boolean onProjectileImpact(Entity entity, HitResult ray) {
@@ -120,7 +417,62 @@ public class ForgeEventFactory {
 		return EntityEvents.onProjectileImpact(throwable, ray);
 	}
 
-	public static int onItemPickup(ItemEntity item, PlayerEntity player) {
-		return PlayerEvents.onItemPickup(player, item);
+	public static LootTable loadLootTable(Identifier name, LootTable table, LootManager lootTableManager) {
+		return LootEvents.loadLootTable(name, table, lootTableManager);
+	}
+
+	@Stubbed
+	public static boolean canCreateFluidSource(World world, BlockPos pos, BlockState state, boolean def) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	/*
+	@Stubbed
+	public static boolean onTrySpawnPortal(IWorld world, BlockPos pos, PortalBlock.AreaHelper size) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	} */
+
+	@Stubbed
+	public static int onEnchantmentLevelSet(World world, BlockPos pos, int enchantRow, int power, ItemStack itemStack, int level) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static boolean onEntityDestroyBlock(LivingEntity entity, BlockPos pos, BlockState state) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static boolean gatherCollisionBoxes(World world, Entity entity, Box aabb, List<Box> outList) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static boolean getMobGriefingEvent(World world, Entity entity) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	public static boolean saplingGrowTree(IWorld world, Random rand, BlockPos pos) {
+		return WorldEvents.onSaplingGrowTree(world, rand, pos);
+	}
+
+	@Stubbed
+	public static void fireChunkWatch(boolean watch, ServerPlayerEntity entity, ChunkPos chunkpos, ServerWorld world) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static boolean onPistonMovePre(World world, BlockPos pos, Direction direction, boolean extending) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static boolean onPistonMovePost(World world, BlockPos pos, Direction direction, boolean extending) {
+		throw new NotImplementedException("ForgeEventFactory stub");
+	}
+
+	@Stubbed
+	public static long onSleepFinished(ServerWorld world, long newTime, long minTime) {
+		throw new NotImplementedException("ForgeEventFactory stub");
 	}
 }

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -78,9 +78,11 @@ import net.patchworkmc.impl.event.world.WorldEvents;
 import net.patchworkmc.impl.extensions.block.BlockHarvestManager;
 import net.patchworkmc.annotations.Stubbed;
 
-/*
- * Note: this class is intended for mod use only, to dispatch to the implementations kept in their own modules.
- * Do not keep implementation details here, methods should be thin wrappers around methods in other modules.
+/**
+ * A stubbed out copy of Forge's ForgeEventFactory, intended for use by Forge mods only.
+ * For methods that you are implementing, don't keep implementation details here.
+ * Elements should be thin wrappers around methods in other modules.
+ * Do not depend on this class in other modules.
  */
 public class ForgeEventFactory {
 	/*

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/fml/client/ClientHooks.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/fml/client/ClientHooks.java
@@ -19,13 +19,104 @@
 
 package net.minecraftforge.fml.client;
 
+import java.io.File;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Table;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
+import net.minecraft.client.gui.screen.multiplayer.MultiplayerServerListWidget;
+import net.minecraft.client.gui.screen.world.SelectWorldScreen;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.network.ClientConnection;
+import net.minecraft.server.ServerMetadata;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.level.storage.LevelSummary;
 
 import net.patchworkmc.impl.networking.ClientNetworkingEvents;
+import net.patchworkmc.annotations.Stubbed;
 
 public class ClientHooks {
+	//private static final Logger LOGGER = LogManager.getLogger();
+	//private static final Marker CLIENTHOOKS = MarkerManager.getMarker("CLIENTHOOKS");
+	// From FontRenderer.renderCharAtPos
+	//private static final String ALLOWED_CHARS = "\u00c0\u00c1\u00c2\u00c8\u00ca\u00cb\u00cd\u00d3\u00d4\u00d5\u00da\u00df\u00e3\u00f5\u011f\u0130\u0131\u0152\u0153\u015e\u015f\u0174\u0175\u017e\u0207\u0000\u0000\u0000\u0000\u0000\u0000\u0000 !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0000\u00c7\u00fc\u00e9\u00e2\u00e4\u00e0\u00e5\u00e7\u00ea\u00eb\u00e8\u00ef\u00ee\u00ec\u00c4\u00c5\u00c9\u00e6\u00c6\u00f4\u00f6\u00f2\u00fb\u00f9\u00ff\u00d6\u00dc\u00f8\u00a3\u00d8\u00d7\u0192\u00e1\u00ed\u00f3\u00fa\u00f1\u00d1\u00aa\u00ba\u00bf\u00ae\u00ac\u00bd\u00bc\u00a1\u00ab\u00bb\u2591\u2592\u2593\u2502\u2524\u2561\u2562\u2556\u2555\u2563\u2551\u2557\u255d\u255c\u255b\u2510\u2514\u2534\u252c\u251c\u2500\u253c\u255e\u255f\u255a\u2554\u2569\u2566\u2560\u2550\u256c\u2567\u2568\u2564\u2565\u2559\u2558\u2552\u2553\u256b\u256a\u2518\u250c\u2588\u2584\u258c\u2590\u2580\u03b1\u03b2\u0393\u03c0\u03a3\u03c3\u03bc\u03c4\u03a6\u0398\u03a9\u03b4\u221e\u2205\u2208\u2229\u2261\u00b1\u2265\u2264\u2320\u2321\u00f7\u2248\u00b0\u2219\u00b7\u221a\u207f\u00b2\u25a0\u0000";
+	//private static final CharMatcher DISALLOWED_CHAR_MATCHER = CharMatcher.anyOf(ALLOWED_CHARS).negate();
+
+	//private static final Identifier iconSheet = new Identifier(ForgeVersion.MOD_ID, "textures/gui/icons.png");
+	//private static SetMultimap<String, Identifier> missingTextures = HashMultimap.create();
+	//private static Set<String> badTextureDomains = Sets.newHashSet();
+	//private static Table<String, String, Set<Identifier>> brokenTextures = HashBasedTable.create();
+
+	@Stubbed
+	@Nullable
+	public static void processForgeListPingData(ServerMetadata packet, MultiplayerServerListWidget.ServerEntry target) {
+		throw new NotImplementedException("ClientHooks stub");
+	}
+
+	@Stubbed
+	public static void drawForgePingInfo(MultiplayerScreen gui, MultiplayerServerListWidget.ServerEntry target, int x, int y, int width, int relativeMouseX, int relativeMouseY) {
+		throw new NotImplementedException("ClientHooks stub");
+	}
+
+	public static String fixDescription(String description) {
+		return description.endsWith(":NOFML§r") ? description.substring(0, description.length() - 8) + "§r" : description;
+	}
+
+	@Stubbed
+	static File getSavesDir() {
+		throw new NotImplementedException("ClientHooks stub");
+	}
+
+	@Stubbed
+	public static void tryLoadExistingWorld(SelectWorldScreen selectWorldGUI, LevelSummary comparator) {
+		throw new NotImplementedException("ClientHooks stub");
+	}
+
+	@Stubbed
+	private static ClientConnection getClientToServerNetworkManager() {
+		throw new NotImplementedException("ClientHooks stub");
+	}
+
+	@Stubbed
+	public static void handleClientWorldClosing(ClientWorld world) {
+		throw new NotImplementedException("ClientHooks stub");
+	}
+
+	@Stubbed
+	public static String stripSpecialChars(String message) {
+		throw new NotImplementedException("ClientHooks stub");
+	}
+
+	@Stubbed
+	public static void trackMissingTexture(Identifier resourceLocation) {
+		throw new NotImplementedException("ClientHooks stub");
+	}
+
+	@Stubbed
+	public static void trackBrokenTexture(Identifier resourceLocation, String error) {
+		throw new NotImplementedException("ClientHooks stub");
+	}
+
+	@Stubbed
+	public static void logMissingTextureErrors() {
+		throw new NotImplementedException("ClientHooks stub");
+	}
+
 	public static void firePlayerLogin(final ClientPlayerInteractionManager interactionManager, final ClientPlayerEntity player, final ClientConnection clientConnection) {
 		ClientNetworkingEvents.firePlayerLogin(interactionManager, player, clientConnection);
 	}

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/fml/client/ClientHooks.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/fml/client/ClientHooks.java
@@ -20,21 +20,10 @@
 package net.minecraftforge.fml.client;
 
 import java.io.File;
-import java.util.Set;
 
 import javax.annotation.Nullable;
 
-import com.google.common.base.CharMatcher;
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.SetMultimap;
-import com.google.common.collect.Sets;
-import com.google.common.collect.Table;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.Marker;
-import org.apache.logging.log4j.MarkerManager;
 
 import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
 import net.minecraft.client.gui.screen.multiplayer.MultiplayerServerListWidget;

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/fml/client/ClientHooks.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/fml/client/ClientHooks.java
@@ -39,6 +39,12 @@ import net.minecraft.world.level.storage.LevelSummary;
 import net.patchworkmc.impl.networking.ClientNetworkingEvents;
 import net.patchworkmc.annotations.Stubbed;
 
+/**
+ * A stubbed out copy of Forge's ClientHooks, intended for use by Forge mods only.
+ * For methods that you are implementing, don't keep implementation details here.
+ * Elements should be thin wrappers around methods in other modules.
+ * Do not depend on this class in other modules.
+ */
 public class ClientHooks {
 	//private static final Logger LOGGER = LogManager.getLogger();
 	//private static final Marker CLIENTHOOKS = MarkerManager.getMarker("CLIENTHOOKS");

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
@@ -64,8 +64,13 @@ public class BasicEventHooks {
 		PlayerEvents.firePlayerSmeltedEvent(player, smelted);
 	}
 
-	// TODO: onRenderTickStart
-	// TODO: onRenderTickEnd
+	public static void onRenderTickStart(float timer) {
+		LifecycleEvents.fireRenderTickEvent(TickEvent.Phase.START, timer);
+	}
+
+	public static void onRenderTickEnd(float timer) {
+		LifecycleEvents.fireRenderTickEvent(TickEvent.Phase.END, timer);
+	}
 
 	public static void onPlayerPreTick(PlayerEntity player) {
 		LifecycleEvents.firePlayerTickEvent(TickEvent.Phase.START, player);
@@ -97,13 +102,5 @@ public class BasicEventHooks {
 
 	public static void onPostServerTick() {
 		LifecycleEvents.fireServerTickEvent(TickEvent.Phase.END);
-	}
-
-	public static void onRenderTickStart(float timer) {
-		LifecycleEvents.fireRenderTickEvent(TickEvent.Phase.START, timer);
-	}
-
-	public static void onRenderTickEnd(float timer) {
-		LifecycleEvents.fireRenderTickEvent(TickEvent.Phase.END, timer);
 	}
 }

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/fml/hooks/BasicEventHooks.java
@@ -31,9 +31,11 @@ import net.minecraft.world.dimension.DimensionType;
 import net.patchworkmc.impl.event.entity.PlayerEvents;
 import net.patchworkmc.impl.event.lifecycle.LifecycleEvents;
 
-/*
- * Note: this class is intended for mod use only, to dispatch to the implementations kept in their own modules.
- * Do not keep implementation details here, methods should be thin wrappers around methods in other modules.
+/**
+ * A copy of Forge's BasicEventHooks, intended for use by Forge mods only.
+ * For methods that you are implementing, don't keep implementation details here.
+ * Elements should be thin wrappers around methods in other modules.
+ * Do not depend on this class in other modules.
  */
 public class BasicEventHooks {
 	public static void firePlayerChangedDimensionEvent(PlayerEntity player, DimensionType fromDim, DimensionType toDim) {


### PR DESCRIPTION
~~NOTE: current commit only stubs ForgeHooksClient, just to get an idea of what this would look like.~~

Alternative to #202, basically a dead simple approach to reducing conflicts by adding more context.

Somewhat tedious to setup, but there's no underlying complexity that could bite us in the ass later.

Also introduces an annotation to mark stubbed items so that we can detect them in other tools (like patcher?)