### PR TITLE
Make methods needed for Iron Chests accessible

### DIFF
--- a/patchwork-fml/src/main/resources/patchwork-fml.accesswidener
+++ b/patchwork-fml/src/main/resources/patchwork-fml.accesswidener
@@ -1,2 +1,4 @@
 accessWidener   v1  named
 accessible  field   net/minecraft/client/MinecraftClient    textureManager  Lnet/minecraft/client/texture/TextureManager;
+accessible  method  net/minecraft/client/gui/screen/Screens register        (Lnet/minecraft/container/ContainerType;Lnet/minecraft/client/gui/screen/Screens$Provider;)V
+accessible  method  net/minecraft/container/ContainerType   <init>          (Lnet/minecraft/container/ContainerType$Factory;)V


### PR DESCRIPTION
PR makes two methods needed for Iron Chests to launch accessible.

Screenshots:

![2020-11-26_15 18 24](https://user-images.githubusercontent.com/594124/100394530-a9153180-2ffa-11eb-89ec-19371780aa82.png)

![2020-11-26_15 06 11](https://user-images.githubusercontent.com/594124/100394449-723f1b80-2ffa-11eb-85a6-5ad642d3dc18.png)

Happy to change location of Access Widener rulesl