### PR TITLE
Changes for Neat

### DIFF
--- a/patchwork-events-rendering/src/main/java/net/minecraftforge/client/event/RenderWorldLastEvent.java
+++ b/patchwork-events-rendering/src/main/java/net/minecraftforge/client/event/RenderWorldLastEvent.java
@@ -1,0 +1,42 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import net.minecraftforge.eventbus.api.Event;
+
+import net.minecraft.client.render.WorldRenderer;
+
+public class RenderWorldLastEvent extends Event {
+	private final WorldRenderer context;
+	private final float partialTicks;
+
+	public RenderWorldLastEvent(WorldRenderer context, float partialTicks) {
+		this.context = context;
+		this.partialTicks = partialTicks;
+	}
+
+	public WorldRenderer getContext() {
+		return context;
+	}
+
+	public float getPartialTicks() {
+		return partialTicks;
+	}
+}

--- a/patchwork-events-rendering/src/main/java/net/patchworkmc/impl/event/render/RenderEvents.java
+++ b/patchwork-events-rendering/src/main/java/net/patchworkmc/impl/event/render/RenderEvents.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.client.event.DrawBlockHighlightEvent;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.ModLoader;
@@ -69,5 +70,9 @@ public class RenderEvents {
 		default:
 			return MinecraftForge.EVENT_BUS.post(new DrawBlockHighlightEvent(context, info, target, subID, partialTicks));
 		}
+	}
+
+	public static void onRenderLast(WorldRenderer context, float tickDelta) {
+		MinecraftForge.EVENT_BUS.post(new RenderWorldLastEvent(context, tickDelta));
 	}
 }

--- a/patchwork-events-rendering/src/main/java/net/patchworkmc/impl/event/render/RenderEvents.java
+++ b/patchwork-events-rendering/src/main/java/net/patchworkmc/impl/event/render/RenderEvents.java
@@ -72,7 +72,7 @@ public class RenderEvents {
 		}
 	}
 
-	public static void onRenderLast(WorldRenderer context, float tickDelta) {
+	public static void onRenderWorldLast(WorldRenderer context, float tickDelta) {
 		MinecraftForge.EVENT_BUS.post(new RenderWorldLastEvent(context, tickDelta));
 	}
 }

--- a/patchwork-events-rendering/src/main/java/net/patchworkmc/mixin/event/render/MixinGameRenderer.java
+++ b/patchwork-events-rendering/src/main/java/net/patchworkmc/mixin/event/render/MixinGameRenderer.java
@@ -58,6 +58,6 @@ public abstract class MixinGameRenderer {
 	@Inject(method = "renderCenter", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;getProfiler()Lnet/minecraft/util/profiler/Profiler;", ordinal = 15), locals = LocalCapture.CAPTURE_FAILHARD)
 	private void hookRenderWorldLastEvent(float tickDelta, long endTime, CallbackInfo ci, WorldRenderer context) {
 		this.client.getProfiler().swap("forge_render_last");
-		RenderEvents.onRenderLast(context, tickDelta);
+		RenderEvents.onRenderWorldLast(context, tickDelta);
 	}
 }

--- a/patchwork-fml/src/main/resources/patchwork-fml.accesswidener
+++ b/patchwork-fml/src/main/resources/patchwork-fml.accesswidener
@@ -1,4 +1,5 @@
 accessWidener   v1  named
-accessible  field   net/minecraft/client/MinecraftClient    textureManager  Lnet/minecraft/client/texture/TextureManager;
-accessible  method  net/minecraft/client/gui/screen/Screens register        (Lnet/minecraft/container/ContainerType;Lnet/minecraft/client/gui/screen/Screens$Provider;)V
-accessible  method  net/minecraft/container/ContainerType   <init>          (Lnet/minecraft/container/ContainerType$Factory;)V
+accessible  field   net/minecraft/client/MinecraftClient    textureManager   Lnet/minecraft/client/texture/TextureManager;
+accessible  method  net/minecraft/client/gui/screen/Screens register         (Lnet/minecraft/container/ContainerType;Lnet/minecraft/client/gui/screen/Screens$Provider;)V
+accessible  method  net/minecraft/container/ContainerType   <init>           (Lnet/minecraft/container/ContainerType$Factory;)V
+accessible  method  net/minecraft/entity/Entity             getSavedEntityId ()Ljava/lang/String;


### PR DESCRIPTION
Adds RenderWorldLastEvent and an AW for `Entity.getSavedEntityId()`. These changes are required for [Neat](https://www.curseforge.com/minecraft/mc-mods/neat). 

Note that Neat does not work when patched with upstream Patcher, as there is a bug where SRG constant strings are not remapped. I have [a fork](https://github.com/stairman06/patchwork-patcher/tree/stringconstant-hack) (`stringconstant-hack` branch) which re-adds the remapping functionality. I can PR to Patcher if that is what I should do, however there is probably a better way to solve the problem than what I did in my fork.