### PR TITLE
Fix JIJ ModInstance construction

### DIFF
--- a/patchwork-dispatcher/src/main/java/net/patchworkmc/impl/Patchwork.java
+++ b/patchwork-dispatcher/src/main/java/net/patchworkmc/impl/Patchwork.java
@@ -105,7 +105,7 @@ public class Patchwork {
 				if (children != null) {
 					for (CustomValue customValue : children.getAsArray()) {
 						String childId = customValue.getAsString();
-						modInitializers.add(new Pair<>(childId, () -> createModInstance(modId)));
+						modInitializers.add(new Pair<>(childId, () -> createModInstance(childId)));
 					}
 				}
 			}


### PR DESCRIPTION
The code here before was preventing child mod ModInstance classes from being constructed properly. This seems like it was the intention here, and it just had a small typo.