### PR TITLE
Implement Item Events

### DIFF
--- a/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/item/ItemEvent.java
+++ b/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/item/ItemEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.item;
+
+import net.minecraftforge.event.entity.EntityEvent;
+
+import net.minecraft.entity.ItemEntity;
+
+/**
+ * Base class for all ItemEntity events, containing a reference to the
+ * ItemEntity of interest.
+ */
+public class ItemEvent extends EntityEvent {
+	private final ItemEntity itemEntity;
+
+	/**
+	 * Creates a new event for an ItemEntity.
+	 *
+	 * @param itemEntity The ItemEntity for this event
+	 */
+	public ItemEvent(ItemEntity itemEntity) {
+		super(itemEntity);
+		this.itemEntity = itemEntity;
+	}
+
+	/**
+	 * The relevant ItemEntity for this event.
+	 */
+	public ItemEntity getEntityItem() {
+		return itemEntity;
+	}
+}

--- a/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/item/ItemExpireEvent.java
+++ b/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/item/ItemExpireEvent.java
@@ -1,0 +1,55 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.item;
+
+import net.minecraft.entity.ItemEntity;
+
+/**
+ * Event that is fired when an ItemEntity's age has reached its maximum
+ * lifespan. If cancelled, the ItemEntity will not be removed from the world,
+ * add extraLife time will be added to the item's life.
+ */
+public class ItemExpireEvent extends ItemEvent {
+	private int extraLife;
+
+	/**
+	 * Creates a new event for an expiring ItemEntity.
+	 *
+	 * @param itemEntity The ItemEntity being deleted.
+	 * @param extraLife The amount of time to be added to this entities lifespan if the event is canceled.
+	 */
+	public ItemExpireEvent(ItemEntity itemEntity, int extraLife) {
+		super(itemEntity);
+		this.setExtraLife(extraLife);
+	}
+
+	public int getExtraLife() {
+		return this.extraLife;
+	}
+
+	public void setExtraLife(int extraLife) {
+		this.extraLife = extraLife;
+	}
+
+	@Override
+	public boolean isCancelable() {
+		return true;
+	}
+}

--- a/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/item/ItemTossEvent.java
+++ b/patchwork-events-entity/src/main/java/net/minecraftforge/event/entity/item/ItemTossEvent.java
@@ -1,0 +1,56 @@
+/*
+ * Minecraft Forge, Patchwork Project
+ * Copyright (c) 2016-2020, 2019-2020
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.item;
+
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.entity.player.PlayerEntity;
+
+/**
+ * Event that is fired whenever a player tosses (Q) an item or drag-n-drops a
+ * stack of items outside the inventory GUI screens. If cancelled, the items
+ * entity will not be created, but the items will be removed from the player's
+ * inventory.
+ */
+public class ItemTossEvent extends ItemEvent {
+	private final PlayerEntity player;
+
+	/**
+	 * Creates a new event for ItemEntities tossed by a player.
+	 *
+	 * @param itemEntity The ItemEntity being tossed.
+	 * @param player The player tossing the item.
+	 */
+	public ItemTossEvent(ItemEntity itemEntity, PlayerEntity player) {
+		super(itemEntity);
+		this.player = player;
+	}
+
+	/**
+	 * The player tossing the item.
+	 */
+	public PlayerEntity getPlayer() {
+		return player;
+	}
+
+	@Override
+	public boolean isCancelable() {
+		return true;
+	}
+}

--- a/patchwork-events-entity/src/main/java/net/patchworkmc/impl/event/entity/EntityEvents.java
+++ b/patchwork-events-entity/src/main/java/net/patchworkmc/impl/event/entity/EntityEvents.java
@@ -22,10 +22,8 @@ package net.patchworkmc.impl.event.entity;
 import java.util.List;
 import java.util.Collection;
 
-import com.google.common.collect.Lists;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.extensions.IForgeItem;
-import net.minecraftforge.common.extensions.IForgeEntity;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.EntityTravelToDimensionEvent;
@@ -218,26 +216,8 @@ public class EntityEvents implements ModInitializer {
 		return MinecraftForge.EVENT_BUS.post(event) ? event.getExtraLife() : -1;
 	}
 
-	public static ItemEntity onPlayerTossEvent(PlayerEntity player, ItemStack item, boolean includeName) {
-		((IForgeEntity) player).captureDrops(Lists.newArrayList());
-		ItemEntity ret = player.dropItem(item, false, includeName);
-		((IForgeEntity) player).captureDrops(null);
-
-		if (ret == null) {
-			return null;
-		}
-
-		ItemTossEvent event = new ItemTossEvent(ret, player);
-
-		if (MinecraftForge.EVENT_BUS.post(event)) {
-			return null;
-		}
-
-		if (!player.world.isClient) {
-			player.getEntityWorld().spawnEntity(event.getEntityItem());
-		}
-
-		return event.getEntityItem();
+	public static boolean onPlayerTossEvent(PlayerEntity player, ItemEntity itemEntity) {
+		return MinecraftForge.EVENT_BUS.post(new ItemTossEvent(itemEntity, player));
 	}
 
 	public static boolean onProjectileImpact(Entity entity, HitResult ray) {

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -209,7 +209,8 @@ public class ForgeHooks {
 
 	@Nullable
 	public static ItemEntity onPlayerTossEvent(@Nonnull PlayerEntity player, @Nonnull ItemStack item, boolean includeName) {
-		return EntityEvents.onPlayerTossEvent(player, item, includeName);
+		// EntityEvents.onPlayerTossEvent is called through an Inject mixin into PlayerEntity.dropItem
+		return player.dropItem(item, false, includeName);
 	}
 
 	@Stubbed

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -207,10 +207,9 @@ public class ForgeHooks {
 		throw new NotImplementedException("ForgeHooks stub");
 	}
 
-	@Stubbed
 	@Nullable
 	public static ItemEntity onPlayerTossEvent(@Nonnull PlayerEntity player, @Nonnull ItemStack item, boolean includeName) {
-		throw new NotImplementedException("ForgeHooks stub");
+		return EntityEvents.onPlayerTossEvent(player, item, includeName);
 	}
 
 	@Stubbed

--- a/patchwork-god-classes/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/patchwork-god-classes/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -273,9 +273,8 @@ public class ForgeEventFactory {
 		throw new NotImplementedException("ForgeEventFactory stub");
 	} */
 
-	@Stubbed
 	public static int onItemExpire(ItemEntity entity, @Nonnull ItemStack item) {
-		throw new NotImplementedException("ForgeEventFactory stub");
+		return EntityEvents.onItemExpire(entity, item);
 	}
 
 	public static int onItemPickup(ItemEntity item, PlayerEntity player) {


### PR DESCRIPTION
This PR implements everything in `net.minecraftforge.event.entity.item`. Implementations differ slightly from forge, notably in onPlayerTossEvent (https://github.com/PatchworkMC/YarnForge/blob/af120a35c3e6951b7ef4318801b6b8dce6fc5420/src/main/java/net/minecraftforge/common/ForgeHooks.java#L428). As far as I can tell, this needlessly replaces calls to `PlayerEntity#dropItem(ItemStack, boolean, boolean)` and calls it instead in `ForgeHooks`, and has to deal with spawning the item manually. Instead, this PR injects into `dropItem(ItemStack, boolean, boolean)` directly.

Corresponding testmods PR: PatchworkMC/patchwork-testmods#5